### PR TITLE
Don't use `su` to run the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN npm --loglevel warn install --production
 COPY . /app
 RUN npm --loglevel warn run postinstall
 
-CMD node /app/app.js
+CMD /app/run.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: redis
 
   nginx-proxy:
-    image: quay.io/ukhomeofficedigital/nginx-proxy:v1.5.1
+    image: quay.io/ukhomeofficedigital/nginx-proxy-govuk:v3.0.0.0
     environment:
       - PROXY_SERVICE_HOST=app
       - PROXY_SERVICE_PORT=8080
@@ -25,8 +25,8 @@ services:
       - ADD_NGINX_SERVER_CFG=add_header Cache-Control private;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;location /public {add_header Cache-Control max-age=86400;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;alias /app/public;}
       - ERROR_REDIRECT_CODES=599
     ports:
-      - "443:443"
-      - "80:80"
+      - "10443:10443"
+      - "10080:10080"
     links:
       - app
     volumes_from:

--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,4 @@ fi
 
 cp -r /app/public/* /public/
 
-su nodejs -c 'exec node index.js'
+node index.js


### PR DESCRIPTION
The latest version of nginx-proxy, which is used by this app to proxy requests upstream, doesn't allow the app to be run as root. 