### PR TITLE
Clean up unused/unspecified packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
     "hof-behaviour-address-lookup": "^1.1.0",
     "hof-build": "^1.3.4",
     "hof-component-date": "^1.0.0",
-    "hof-confirm-controller": "^1.0.1",
-    "hof-controllers": "^6.0.1",
     "hof-frontend-toolkit": "^2.1.0",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.1.1",
+    "lodash": "^4.17.4",
     "typeahead-aria": "^1.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The two hof packages were being installed but not used.

Lodash was being required, but not listed as a dependency.