### PR TITLE
Use hof-theme-govuk@2

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -1,4 +1,4 @@
-@import "hof-frontend-toolkit";
+@import "hof-theme-govuk";
 
 h1 {
   @include bold-24;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "hof-confirm-controller": "^1.0.1",
     "hof-controllers": "^6.0.1",
     "hof-frontend-toolkit": "^2.1.0",
+    "hof-theme-govuk": "^2.0.4",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.1.1",
     "typeahead-aria": "^1.0.4"


### PR DESCRIPTION
Because `hof` loads the latest theme by default if none is specified in the parent project then it is combining the old css from `hof-frontend-toolkit` and the new html from the theme at version 3.

By specifying the theme at version 2 then we ensure the html and css remain in sync.