### PR TITLE
Add another tenant

### DIFF
--- a/apps/right-to-rent-check/behaviours/tenants.js
+++ b/apps/right-to-rent-check/behaviours/tenants.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const _ = require('lodash');
+
+module.exports = fields => {
+
+  return superclass => class extends superclass {
+
+    saveValues(req, res, callback) {
+      const name = req.body['tenant-name'];
+      const tenants = req.sessionModel.get('tenants') || [];
+
+      let tenant = _.find(tenants, {'tenant-name': name});
+      if (!tenant) {
+        tenant = fields.length ? _.pick(req.body, fields) : req.body;
+        if (!_.isEmpty(tenant)) {
+          tenants.push(tenant);
+        }
+      } else {
+        Object.assign(tenant, _.pick(req.body, fields));
+      }
+
+      req.sessionModel.set('tenants', tenants);
+
+      super.saveValues(req, res, callback);
+    }
+
+  };
+
+};

--- a/apps/right-to-rent-check/fields.js
+++ b/apps/right-to-rent-check/fields.js
@@ -88,6 +88,17 @@ module.exports = {
       value: 'recorded-delivery-number'
     }
   },
+  'tenant-add-another': {
+    mixin: 'radio-group',
+    validate: 'required',
+    legend: {
+      className: 'visuallyhidden'
+    },
+    options: [
+      'yes',
+      'no'
+    ]
+  },
   'agent-company': {
     mixin: 'input-text',
     validate: 'required'

--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -60,7 +60,6 @@ module.exports = {
       next: '/tenant-details'
     },
     '/tenant-details': {
-      behaviours: [tenants],
       fields: [
         'tenant-name',
         'tenant-dob',
@@ -69,7 +68,6 @@ module.exports = {
       next: '/tenant-additional-details'
     },
     '/tenant-additional-details': {
-      behaviours: [tenants],
       fields: [
         'tenant-name',
         'tenant-dob',

--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -1,6 +1,15 @@
 'use strict';
 
 const AddressLookup = require('hof-behaviour-address-lookup');
+const tenants = require('./behaviours/tenants')([
+  'tenant-name',
+  'tenant-dob',
+  'tenant-country',
+  'tenant-reference-number',
+  'tenant-passport-number',
+  'tenant-brp-number',
+  'tenant-recorded-delivery-number'
+]);
 const config = require('../../config');
 
 module.exports = {
@@ -51,6 +60,7 @@ module.exports = {
       next: '/tenant-details'
     },
     '/tenant-details': {
+      behaviours: [tenants],
       fields: [
         'tenant-name',
         'tenant-dob',
@@ -59,7 +69,11 @@ module.exports = {
       next: '/tenant-additional-details'
     },
     '/tenant-additional-details': {
+      behaviours: [tenants],
       fields: [
+        'tenant-name',
+        'tenant-dob',
+        'tenant-country',
         'tenant-additional-details',
         'tenant-reference-number',
         'tenant-passport-number',
@@ -69,7 +83,18 @@ module.exports = {
       next: '/tenant-another'
     },
     '/tenant-another': {
-      next: '/landlord-agent'
+      behaviours: [tenants],
+      fields: [
+        'tenant-add-another',
+      ],
+      next: '/landlord-agent',
+      forks: [{
+        target: '/tenant-details',
+        condition: {
+          field: 'tenant-add-another',
+          value: 'yes'
+        }
+      }]
     },
     '/landlord-agent': {
       fields: [

--- a/apps/right-to-rent-check/translations/src/en/fields.json
+++ b/apps/right-to-rent-check/translations/src/en/fields.json
@@ -55,6 +55,16 @@
     "label": "Recorded delivery number",
     "hint": "For example, 'AB123456789GB'."
   },
+  "tenant-add-another": {
+    "options": {
+      "yes": {
+        "label": "Yes I want to add another tenant"
+      },
+      "no": {
+        "label": "No I do not want to add another"
+      }
+    }
+  },
   "agent-name": {
     "label": "Your full name",
     "summary": "Name"

--- a/apps/right-to-rent-check/translations/src/en/pages.json
+++ b/apps/right-to-rent-check/translations/src/en/pages.json
@@ -24,7 +24,7 @@
     "header": "What additional information can you provide for {{values.tenant-name}}?"
   },
   "tenant-another": {
-    "header": "Placeholder page"
+    "header": "Is there another person on the same tenancy you'd like to request a check for?"
   },
   "property-address": {
     "header": "What's the rental property address?"

--- a/apps/right-to-rent-check/translations/src/en/pages.json
+++ b/apps/right-to-rent-check/translations/src/en/pages.json
@@ -24,7 +24,21 @@
     "header": "What additional information can you provide for {{values.tenant-name}}?"
   },
   "tenant-another": {
-    "header": "Is there another person on the same tenancy you'd like to request a check for?"
+    "header": "Is there another person on the same tenancy you'd like to request a check for?",
+    "tables": {
+      "headers": {
+        "name": "Name",
+        "dob": "Date of birth",
+        "country": "Country of nationality",
+        "reference": "Home Office reference number",
+        "passport": "Passport number",
+        "brp": "Biometric Residence Permit number",
+        "recorded-delivery": "Recorded delivery number of latest application"
+      },
+      "values": {
+        "undefined": "Not provided"
+      }
+    }
   },
   "property-address": {
     "header": "What's the rental property address?"

--- a/apps/right-to-rent-check/translations/src/en/validation.json
+++ b/apps/right-to-rent-check/translations/src/en/validation.json
@@ -1,4 +1,10 @@
 {
+  "property-address-postcode": {
+    "required": "Please enter your postcode"
+  },
+  "property-address": {
+    "required": "Please enter your address"
+  },
   "living-status": {
     "required": "Select an option"
   },
@@ -29,6 +35,9 @@
   },
   "tenant-recorded-delivery-number": {
     "required": "Enter the recorded delivery number"
+  },
+  "tenant-add-another": {
+    "required": "Select an option"
   },
   "agent-company": {
     "required": "Enter your company name"

--- a/apps/right-to-rent-check/views/content/tenant-another.md
+++ b/apps/right-to-rent-check/views/content/tenant-another.md
@@ -1,0 +1,5 @@
+You can add another person now if their circumstances are similar, for instance they are already living in the property/are not living in the property.
+
+Remember they must also be 18 or over, already in the UK and unable to provide documents (if they can provide documents you should do the check yourself)
+
+There will be an opportunity after you have submitted this form to start a new request.

--- a/apps/right-to-rent-check/views/tenant-another.html
+++ b/apps/right-to-rent-check/views/tenant-another.html
@@ -5,5 +5,40 @@
       {{#renderField}}{{/renderField}}
     {{/fields}}
     {{#input-submit}}continue{{/input-submit}}
+    <h2>Tenants details</h2>
+    {{#tenants}}
+      <table class="tenant-details">
+        <tbody>
+          <tr>
+            <th>{{#t}}pages.tenant-another.tables.headers.name{{/t}}</th>
+            <td>{{tenant-name}}</td>
+          </tr>
+          <tr>
+            <th>{{#t}}pages.tenant-another.tables.headers.dob{{/t}}</th>
+            <td>{{tenant-dob}}</td>
+          </tr>
+          <tr>
+            <th>{{#t}}pages.tenant-another.tables.headers.country{{/t}}</th>
+            <td>{{tenant-country}}</td>
+          </tr>
+          <tr>
+            <th>{{#t}}pages.tenant-another.tables.headers.reference{{/t}}</th>
+            <td>{{tenant-reference-number}}{{^tenant-reference-number}}{{#t}}pages.tenant-another.tables.values.undefined{{/t}}{{/tenant-reference-number}}</td>
+          </tr>
+          <tr>
+            <th>{{#t}}pages.tenant-another.tables.headers.passport{{/t}}</th>
+            <td>{{tenant-passport-number}}{{^tenant-passport-number}}{{#t}}pages.tenant-another.tables.values.undefined{{/t}}{{/tenant-passport-number}}</td>
+          </tr>
+          <tr>
+            <th>{{#t}}pages.tenant-another.tables.headers.brp{{/t}}</th>
+            <td>{{tenant-brp-number}}{{^tenant-brp-number}}{{#t}}pages.tenant-another.tables.values.undefined{{/t}}{{/tenant-brp-number}}</td>
+          </tr>
+          <tr>
+            <th>{{#t}}pages.tenant-another.tables.headers.recorded-delivery{{/t}}</th>
+            <td>{{tenant-recorded-delivery-number}}{{^tenant-recorded-delivery-number}}{{#t}}pages.tenant-another.tables.values.undefined{{/t}}{{/tenant-recorded-delivery-number}}</td>
+          </tr>
+        </tbody>
+      </table>
+    {{/tenants}}
   {{/page-content}}
 {{/partials-page}}

--- a/apps/right-to-rent-check/views/tenant-another.html
+++ b/apps/right-to-rent-check/views/tenant-another.html
@@ -1,0 +1,9 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#markdown}}tenant-another{{/markdown}}
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -62,11 +62,19 @@ h1 {
   }
 }
 
-.phase-banner {
-  @include phase-banner(beta);
-}
-
 .form-group label h3 {
   margin-top: 0;
   margin-bottom: 0;
+}
+
+table.tenant-details {
+  border-top: 1px #aaa solid;
+  border-collapse: separate;
+  padding: 15px 0;
+  th, td {
+    border: none;
+  }
+  th {
+    font-weight: 600;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "start": "node app.js",
     "dev": "hof-build watch",
-    "test": "npm run test:lint",
+    "test": "NODE_ENV=test npm run test:unit && npm run test:lint",
+    "test:unit": "_mocha",
     "test:lint": "eslint .",
     "test:acceptance": "funkie so-acceptance --steps",
     "build": "hof-build",
@@ -23,11 +24,16 @@
     "typeahead-aria": "^1.0.4"
   },
   "devDependencies": {
+    "chai": "^4.1.0",
     "eslint": "^3.14.0",
     "eslint-config-homeoffice": "^2.1.0",
     "express": "^4.15.2",
     "funkie": "0.0.5",
     "funkie-phantom": "0.0.1",
+    "mocha": "^3.4.2",
+    "reqres": "^1.3.0",
+    "sinon": "^2.4.0",
+    "sinon-chai": "^2.12.0",
     "so-acceptance": "^4.2.5"
   },
   "name": "right-to-rent-check",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+extends:
+  - '../.eslintrc'
+  - 'homeoffice/config/testing'
+
+env:
+  es6: true

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,8 @@
+'use strict';
+
+global.chai = require('chai')
+  .use(require('sinon-chai'));
+global.expect = chai.expect;
+global.sinon = require('sinon');
+process.setMaxListeners(0);
+process.stdout.setMaxListeners(0);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--require test/common.js
+--recursive
+--reporter spec

--- a/test/unit/behaviours/tenants.js
+++ b/test/unit/behaviours/tenants.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const reqres = require('reqres');
+const Behaviour = require('../../../apps/right-to-rent-check/behaviours/tenants');
+
+describe('behaviours/tenants', () => {
+
+  it('exports a function', () => {
+    expect(Behaviour).to.be.a('function');
+  });
+
+  describe('initialisation', () => {
+
+    it('returns a mixin', () => {
+      const fields = ['tenant-name'];
+      class Base {}
+      const Mixed = Behaviour(fields)(Base);
+      expect(new Mixed()).to.be.an.instanceOf(Base);
+    });
+
+  });
+
+  describe('saveValues', () => {
+
+    class Base {
+      saveValues() {}
+    }
+    let fields;
+    let sessionModel;
+    let controller;
+    let Tenants;
+    let req;
+    let res;
+
+    beforeEach(() => {
+      fields = [
+        'tenant-name',
+        'tenant-age',
+        'tenant-address'
+      ];
+      sessionModel = {
+        get: sinon.stub(),
+        set: sinon.stub(),
+      };
+      res = reqres.res();
+      sinon.stub(Base.prototype, 'saveValues').yields();
+      Tenants = Behaviour(fields)(Base);
+      controller = new Tenants();
+    });
+
+    afterEach(() => {
+      Base.prototype.saveValues.restore();
+    });
+
+    it('saves a collection of tenants to the sessionModel', (done) => {
+
+      req = reqres.req({
+        sessionModel,
+        body: {
+          'tenant-name': 'john smith',
+          'tenant-age': '24'
+        }
+      });
+
+      const tenants = [{
+        'tenant-name': 'john smith',
+        'tenant-age': '24'
+      }];
+
+      controller.saveValues(req, res, (err) => {
+        expect(err).not.to.exist;
+        expect(req.sessionModel.set).to.have.been.calledOnce;
+        expect(req.sessionModel.set.args[0][0]).to.equal('tenants');
+        expect(req.sessionModel.set.args[0][1]).to.deep.equal(tenants);
+        done();
+      });
+
+    });
+
+    it('calls super.saveValues with the request and response objects', (done) => {
+
+      req = reqres.req({
+        sessionModel,
+        body: {
+          'tenant-name': 'john smith',
+          'tenant-age': '24'
+        }
+      });
+
+      controller.saveValues(req, res, (err) => {
+        expect(err).not.to.exist;
+        expect(Base.prototype.saveValues).to.have.been.calledWith(
+          req,
+          res,
+          sinon.match.func
+        );
+        done();
+      });
+
+    });
+
+    it('updates existing tenants', (done) => {
+
+      sessionModel.get.returns([{
+        'tenant-name': 'John Smith',
+        'tenant-age': '42'
+      }]);
+
+      req = reqres.req({
+        sessionModel,
+        body: {
+          'tenant-name': 'John Smith',
+          'tenant-age': '42',
+          'tenant-address': 'London'
+        }
+      });
+
+      const tenants = [{
+        'tenant-name': 'John Smith',
+        'tenant-age': '42',
+        'tenant-address': 'London'
+      }];
+
+      controller.saveValues(req, res, (err) => {
+        expect(err).not.to.exist;
+        expect(req.sessionModel.set).to.have.been.calledOnce;
+        expect(req.sessionModel.set.args[0][0]).to.equal('tenants');
+        expect(req.sessionModel.set.args[0][1]).to.deep.equal(tenants);
+        done();
+      });
+
+    });
+
+    it('adds new tenants', (done) => {
+
+      sessionModel.get.returns([{
+        'tenant-name': 'John Smith',
+        'tenant-age': '42'
+      }]);
+
+      req = reqres.req({
+        sessionModel,
+        body: {
+          'tenant-name': 'Karen Smith',
+          'tenant-age': '43'
+        }
+      });
+
+      const tenants = [{
+        'tenant-age': '42',
+        'tenant-name': 'John Smith'
+      }, {
+        'tenant-age': '43',
+        'tenant-name': 'Karen Smith'
+      }];
+
+      controller.saveValues(req, res, (err) => {
+        expect(err).not.to.exist;
+        expect(req.sessionModel.set).to.have.been.calledOnce;
+        expect(req.sessionModel.set.args[0][0]).to.equal('tenants');
+        expect(req.sessionModel.set.args[0][1]).to.deep.equal(tenants);
+        done();
+      });
+
+    });
+
+    it('adds configured fields', (done) => {
+
+      fields = [
+        'tenant-name',
+        'tenant-age',
+      ];
+
+      Tenants = Behaviour(fields)(Base);
+      controller = new Tenants();
+
+      req = reqres.req({
+        sessionModel,
+        body: {
+          'tenant-name': 'Karen Smith',
+          'tenant-age': '43',
+          'not-a-field': true
+        }
+      });
+
+      const tenants = [{
+        'tenant-name': 'Karen Smith',
+          'tenant-age': '43',
+      }];
+
+      controller.saveValues(req, res, (err) => {
+        expect(err).not.to.exist;
+        expect(req.sessionModel.set).to.have.been.calledOnce;
+        expect(req.sessionModel.set.args[0][0]).to.equal('tenants');
+        expect(req.sessionModel.set.args[0][1]).to.deep.equal(tenants);
+        done();
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
This PR adds commits for the `tenant-another/` step, which should present the added tenants and give the user an opportunity to add another tenant.

These commits load the view with the tenants details and the fields, from which a user can choose to add another tenant or not.

These commits do not incude the edit or delete features.

A second PR will be raised to address the edit/change feature of each tenant.
