### PR TITLE
Fix: Upgrade hof-theme-govuk 3.0.1 to fix the validation summary border not showing properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hof-build": "^1.3.4",
     "hof-component-date": "^1.0.0",
     "hof-frontend-toolkit": "^2.1.0",
-    "hof-theme-govuk": "^3.0.0",
+    "hof-theme-govuk": "^3.0.1",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.1.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
**Before**

<img width="653" alt="validation-summary-not-working" src="https://user-images.githubusercontent.com/12494656/28928921-7a894454-7866-11e7-9302-4403d49a916a.png">

**After**

![validation-summary-working](https://user-images.githubusercontent.com/12494656/28928927-80012a3c-7866-11e7-8ad3-4554a2cb370a.png)
