### PR TITLE
Upgrade to hof 13 & hof-theme-govuk 4.0.0: fixes the issue of session timeout page not going back to start

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "postinstall": "npm run build"
   },
   "dependencies": {
-    "hof": "^12.1.2",
+    "hof": "^13.0.0",
     "hof-behaviour-address-lookup": "^1.1.0",
     "hof-build": "^1.3.4",
     "hof-component-date": "^1.0.0",
     "hof-frontend-toolkit": "^2.1.0",
-    "hof-theme-govuk": "^3.0.1",
+    "hof-theme-govuk": "^4.0.0",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.1.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
hof 13 upgrades hof-middleware 2.0.0. This changes the locals of startLink to the baseUrl or `/` if there is no baseUrl. This is used in the error template

The error template is found in hof-template-partials which is a dependency of hof-theme-govuk NOT hof . hof-template-partials has also been updated to 4.0.0. Remove `/` from startlink of the template, it'll be passed in by locals from hof-middleware.