### PR TITLE
Update /tenant-details validation & content

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/tenant-details.js
+++ b/apps/right-to-rent-check/acceptance/features/tenant-details.js
@@ -46,6 +46,17 @@ Scenario('When I submit a date in the future then I see a future date error', (
   I.seeErrors('#tenant-dob-group');
 });
 
+Scenario('When I submit a date of birth that is less than 18 years then I see a age restriction error', (
+  I,
+  tenantDetailsPage
+) => {
+  I.fillField('#tenant-name', 'aaa');
+  I.fillField('#tenant-country', 'United Kingdom');
+  tenantDetailsPage.enterDate('underage');
+  I.submitForm();
+  I.seeErrors('#tenant-dob-group');
+});
+
 Scenario('When I submit an invalid country name then I see a country error', (
   I
 ) => {

--- a/apps/right-to-rent-check/acceptance/pages/tenant-details.js
+++ b/apps/right-to-rent-check/acceptance/pages/tenant-details.js
@@ -31,10 +31,15 @@ module.exports = {
       month: 'm',
       year: 'y'
     },
+    'underage-date': {
+      day: '1',
+      month: '1',
+      year: (new Date()).getFullYear().toString()
+    },
     'valid-date': {
       day: '1',
       month: '1',
-      year: '2016'
+      year: '1990'
     }
   },
 

--- a/apps/right-to-rent-check/behaviours/age-restriction.js
+++ b/apps/right-to-rent-check/behaviours/age-restriction.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const moment = require('moment');
+
+module.exports = superclass => class extends superclass {
+  validate(req, res, next) {
+    const ageRestriction = moment().subtract(17, 'years').subtract(11, 'months');
+    const tenantDob = moment(req.form.values['tenant-dob']);
+    if (tenantDob > ageRestriction) {
+      next({
+        'tenant-dob': new this.ValidationError('tenant-dob', { type: 'age'})
+      });
+    } else {
+      super.validate(req, res, next);
+    }
+  }
+};

--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const AddressLookup = require('hof-behaviour-address-lookup');
 const checkPilotPostcodeAndDate = require('./behaviours/tenancy-start-postcode-check');
+const ageRestriction = require('./behaviours/age-restriction');
 const tenants = require('./behaviours/tenants')([
   'tenant-name',
   'tenant-dob',
@@ -100,6 +101,7 @@ module.exports = {
       next: '/check-confirmed'
     },
     '/tenant-details': {
+      behaviours: [ageRestriction],
       fields: [
         'tenant-name',
         'tenant-dob',

--- a/apps/right-to-rent-check/translations/src/en/fields.json
+++ b/apps/right-to-rent-check/translations/src/en/fields.json
@@ -54,7 +54,7 @@
     "hint": "For example, 10 3 2016"
   },
   "tenant-name": {
-    "label": "Prospective tenant's full name"
+    "label": "Full name"
   },
   "tenant-dob": {
     "legend": "Date of birth",

--- a/apps/right-to-rent-check/translations/src/en/pages.json
+++ b/apps/right-to-rent-check/translations/src/en/pages.json
@@ -30,7 +30,7 @@
     "header": "What's the person's current address?"
   },
   "tenant-details": {
-    "header": "What are the person's details?"
+    "header": "What are the tenant’s details?"
   },
   "tenant-additional-details": {
     "header": "What additional information can you provide for {{values.tenant-name}}?"

--- a/apps/right-to-rent-check/translations/src/en/validation.json
+++ b/apps/right-to-rent-check/translations/src/en/validation.json
@@ -35,14 +35,16 @@
     "required": "Enter an address"
   },
   "tenant-name": {
-    "required": "Enter the prospective tenant's name"
+    "required": "Enter the tenant's name"
   },
   "tenant-country": {
-    "required": "Enter the prospective tenant's country of nationality"
+    "required": "Enter the tenant's country of nationality",
+    "equal": "Pick a country from the list"
   },
   "tenant-dob": {
-    "required": "Enter a date",
+    "required": "Enter the tenant's date of birth",
     "before": "Date cannot be in the future",
+    "age": "You only need to check tenants who are 18 and over. Enter a valid date of birth",
     "date": "Enter a valid date"
   },
   "tenant-reference-number": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.1.1",
     "lodash": "^4.17.4",
+    "moment": "^2.18.1",
     "typeahead-aria": "^1.0.4",
     "uuid": "^3.1.0"
   },

--- a/test/unit/behaviours/age-restriction.test.js
+++ b/test/unit/behaviours/age-restriction.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const reqres = require('reqres');
+const Behavior = require('../../../apps/right-to-rent-check/behaviours/age-restriction');
+const moment = require('moment');
+
+describe('apps/behaviours/age-restriction', () => {
+  it('exports a function', () => {
+    expect(Behavior).to.be.a('function');
+  });
+
+  class Base {
+    validate() {}
+    ValidationError() {}
+  }
+  let req;
+  let res;
+  let next;
+  let AgeRestriction;
+  let instance;
+  let ValidationError;
+
+  beforeEach(() => {
+    res = reqres.res();
+    req = reqres.req({
+      form: {
+        values: {}
+      }
+    });
+    next = sinon.stub();
+    AgeRestriction = Behavior(Base);
+    instance = new AgeRestriction();
+    sinon.stub(Base.prototype, 'validate');
+    ValidationError = sinon.stub(Base.prototype, 'ValidationError');
+  });
+  afterEach(() => {
+    Base.prototype.validate.restore();
+    Base.prototype.ValidationError.restore();
+  });
+
+  describe('validate()', () => {
+    it('calls parent method when tenant date of birth is greater than 17 years 11 months', () => {
+      const validDob = moment('1990-12-01');
+      req.form.values['tenant-dob'] = validDob;
+      instance.validate(req, res);
+
+      Base.prototype.validate.should.have.been.calledWith(req, res);
+    });
+    describe('when the tenant\'s date of birth is less than than 17 years 11 months', () => {
+      let invalidDob = moment().subtract(1, 'months');
+
+      it('calls next', () => {
+        req.form.values['tenant-dob'] = invalidDob;
+        instance.validate(req, res, next);
+        next.should.have.been.called;
+      });
+
+      describe('the next function', () => {
+        it('has a property of tenant-dob which is an instance of ValidationError', () => {
+          req.form.values['tenant-dob'] = invalidDob;
+          instance.validate(req, res, next);
+          next.getCall(0).args[0]['tenant-dob'].should.be.an.instanceOf(Base.prototype.ValidationError);
+        });
+
+        it('ValidationError is called with the field tenant-dob with the validation type age', () => {
+          req.form.values['tenant-dob'] = invalidDob;
+          instance.validate(req, res, next);
+          ValidationError.should.have.been.calledWith('tenant-dob', {type: 'age'});
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Add an age-restriction behaviour for under 18 validation

I couldn't just use [`before` argument in the config](https://github.com/UKHomeOfficeForms/hof-examples/blob/master/apps/date-component/README.md#date-argument) because I'm already using it for future DOB

Also, I explored the possibility of just using under 18 validation for future dates but this was voted ⬇️ by @karypun @Nadiahuq @jnicholson253 