### PR TITLE
Add /check-confirmed step

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/check-confirmed.js
+++ b/apps/right-to-rent-check/acceptance/features/check-confirmed.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const steps = require('../../');
+
+Feature('Given I am at /check-confirmed');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+});
+
+Scenario('When the page loads then the correct page elements are visible', (
+  I,
+  checkConfirmedPage
+) => {
+  I.visitPage(checkConfirmedPage, steps);
+  I.seeElement('#checkAnswersTable');
+  I.seeElement('a[href="/documents-check"]');
+});
+
+Scenario('When I click the link then I am taken to /documents-check', (
+  I,
+  checkConfirmedPage
+) => {
+  I.completeToStep(`/${checkConfirmedPage.url}`, {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'property-address-postcode': 'CR0 2EU',
+    'property-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
+    'living-status': 'yes',
+    'tenancy-start-day': '1',
+    'tenancy-start-month': '1',
+    'tenancy-start-year': '2017'
+  });
+  I.click('a[href="/documents-check"]');
+  I.seeInCurrentUrl('/documents-check');
+});
+
+Scenario('When I click the Continue button then I see the start page', (
+  I,
+  checkConfirmedPage
+) => {
+  I.visitPage(checkConfirmedPage, steps);
+  I.click('input[type="submit"]');
+  I.seeInCurrentUrl('/start');
+});
+
+Scenario.only('When the user is living in the property then the following tabular data is visible', (
+  I,
+  checkConfirmedPage
+) => {
+  I.completeToStep(`/${checkConfirmedPage.url}`, {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'property-address-postcode': 'CR0 2EU',
+    'property-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
+    'living-status': 'yes',
+    'tenancy-start-day': '1',
+    'tenancy-start-month': '1',
+    'tenancy-start-year': '2017'
+  });
+  I.seeNumberOfElements('#checkAnswersTable tr', 5);
+  I.see('Does the person have documents No', '#checkAnswersTable tr:nth-child(1)');
+  I.see('Where is the rental property England', '#checkAnswersTable tr:nth-child(2)');
+  I.see('What is the rental property address 49 Sydenham Road Croydon CR0 2EU', '#checkAnswersTable tr:nth-child(3)');
+  I.see('Person(s) living in property Yes', '#checkAnswersTable tr:nth-child(4)');
+  I.see('When did they move in 01-01-2017', '#checkAnswersTable tr:nth-child(5)');
+});
+
+Scenario('When the user is not living in the property then the following tabular data is visible', (
+  I,
+  checkConfirmedPage
+) => {
+  I.completeToStep(`/${checkConfirmedPage.url}`, {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'property-address-postcode': 'CR0 2EU',
+    'property-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
+    'living-status': 'no',
+    'tenant-in-uk': 'yes',
+    'current-address-postcode': 'CR0 2EU',
+    'current-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
+  });
+  I.seeNumberOfElements('#checkAnswersTable tr', 6);
+  I.see('Does the person have documents No', '#checkAnswersTable tr:nth-child(1)');
+  I.see('Where is the rental property England', '#checkAnswersTable tr:nth-child(2)');
+  I.see('What is the rental property address 49 Sydenham Road Croydon CR0 2EU', '#checkAnswersTable tr:nth-child(3)');
+  I.see('Person(s) living in property No', '#checkAnswersTable tr:nth-child(4)');
+  I.see('Person(s) living in UK Yes', '#checkAnswersTable tr:nth-child(5)');
+  I.see('Current address 49 Sydenham Road Croydon CR0 2EU', '#checkAnswersTable tr:nth-child(6)');
+});

--- a/apps/right-to-rent-check/acceptance/features/check-confirmed.js
+++ b/apps/right-to-rent-check/acceptance/features/check-confirmed.js
@@ -46,7 +46,7 @@ Scenario('When I click the Continue button then I see the start page', (
   I.seeInCurrentUrl('/start');
 });
 
-Scenario.only('When the user is living in the property then the following tabular data is visible', (
+Scenario('When the user is living in the property then the following tabular data is visible', (
   I,
   checkConfirmedPage
 ) => {

--- a/apps/right-to-rent-check/acceptance/features/tenant-in-uk.js
+++ b/apps/right-to-rent-check/acceptance/features/tenant-in-uk.js
@@ -33,11 +33,11 @@ Scenario('When I select Yes And submit the form Then I am taken to /current-prop
   I.seeInCurrentUrl(currentPropertyAddressPage.url);
 });
 
-Scenario('When I select No And submit the form Then I am taken to the /uk-check-yourself page', (
+Scenario('When I select No And submit the form Then I am taken to the /check-not-needed-uk page', (
   I,
-  ukCheckYourselfPage
+  checkNotNeededUkPage
 ) => {
   I.click('#tenant-in-uk-no');
   I.submitForm();
-  I.seeInCurrentUrl(ukCheckYourselfPage.url);
+  I.seeInCurrentUrl(checkNotNeededUkPage.url);
 });

--- a/apps/right-to-rent-check/acceptance/pages/uk-check-yourself.js
+++ b/apps/right-to-rent-check/acceptance/pages/uk-check-yourself.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  url: 'uk-check-yourself'
-};

--- a/apps/right-to-rent-check/behaviours/rental-questions.js
+++ b/apps/right-to-rent-check/behaviours/rental-questions.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const reverseDateISO = (date) => {
+  return date.replace(/T.*/, '').split('-').reverse().join('-');
+};
+
+module.exports = superclass => class extends superclass {
+
+  locals(req, res) {
+    let view = super.locals(req, res);
+    const data = req.sessionModel.toJSON();
+    const status = data['living-status'];
+    const translate = req.translate;
+
+    const questions = [{
+      question: translate('pages.check-confirmed.table.documents'),
+      answer: data['documents-check']
+    }, {
+      question: translate('pages.check-confirmed.table.where'),
+      answer: data['rental-property-location']
+    }, {
+      question: translate('pages.check-confirmed.table.address'),
+      answer: data['property-address']
+    }, {
+      question: translate('pages.check-confirmed.table.persons'),
+      answer: data['living-status']
+    }];
+
+    if (status === 'yes') {
+      questions.push({
+        question: translate('pages.check-confirmed.table.when'),
+        answer: reverseDateISO(data['tenancy-start'])
+      });
+    } else if (status === 'no') {
+      questions.push({
+        question: translate('pages.check-confirmed.table.uk'),
+        answer: data['tenant-in-uk']
+      }, {
+        question: translate('pages.check-confirmed.table.current'),
+        answer: data['current-address']
+      });
+    }
+
+    view.questions = questions;
+
+    return view;
+  }
+
+};

--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -80,7 +80,6 @@ module.exports = {
       }],
     },
     '/check-not-needed-uk': {},
-    '/uk-check-yourself': {},
     '/tenancy-start-date': {
       behaviours: [checkPilotPostcodeAndDate],
       fields: ['tenancy-start'],

--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -13,6 +13,7 @@ const tenants = require('./behaviours/tenants')([
   'tenant-recorded-delivery-number'
 ]);
 const getDeclarer = require('./behaviours/get-declarer');
+const rentalQuestions = require('./behaviours/rental-questions');
 const config = require('../../config');
 
 module.exports = {
@@ -78,15 +79,16 @@ module.exports = {
         }
       }],
     },
-    '/check-not-needed-uk': {
-    },
+    '/check-not-needed-uk': {},
+    '/uk-check-yourself': {},
     '/tenancy-start-date': {
       behaviours: [checkPilotPostcodeAndDate],
       fields: ['tenancy-start'],
       next: '/check-confirmed'
     },
     '/check-confirmed': {
-      next: '/start'
+      next: '/start',
+      behaviours: [rentalQuestions]
     },
     '/start': {
       next: '/tenant-details'

--- a/apps/right-to-rent-check/translations/src/en/pages.json
+++ b/apps/right-to-rent-check/translations/src/en/pages.json
@@ -31,7 +31,19 @@
     "header": "Placeholder page"
   },
   "check-confirmed": {
-    "header": "Placeholder page"
+    "header": "You can use the Home Office right to rent check",
+    "sub": "These are your answers",
+    "intro": "Please check them carefully. If you need to change anything later, you'll have to start again.",
+    "table": {
+      "documents": "Does the person have documents",
+      "where": "Where is the rental property",
+      "address": "What is the rental property address",
+      "persons": "Person(s) living in property",
+      "uk": "Person(s) living in UK",
+      "current": "Current address",
+      "when": "When did they move in"
+    },
+    "link": "Something’s wrong, start again"
   },
   "start": {
     "custom-header": "Request a Home Office right to rent check"

--- a/apps/right-to-rent-check/views/check-confirmed.html
+++ b/apps/right-to-rent-check/views/check-confirmed.html
@@ -1,0 +1,23 @@
+{{<partials-page}}
+  {{$content}}
+    <form id="checkAnswersForm" action="" method="POST" {{$encoding}}{{/encoding}} autocomplete="off" novalidate="true" spellcheck="false">
+      <p class="form-block"><strong>{{#t}}pages.check-confirmed.sub{{/t}}</strong></p>
+      <p class="form-block">{{#t}}pages.check-confirmed.intro{{/t}}</p>
+      <table id="checkAnswersTable">
+        {{#questions}}
+        <tr>
+          <th>{{question}}</th>
+          <td>{{answer}}</td>
+        </tr>
+        {{/questions}}
+      </table>
+      {{#input-submit}}continue{{/input-submit}}
+      <a href="/documents-check">{{#t}}pages.check-confirmed.link{{/t}}</a>
+      {{#csrf-token}}
+        <input type="hidden" name="x-csrf-token" value="{{csrf-token}}" />
+      {{/csrf-token}}
+    </form>
+  {{/content}}
+{{/partials-page}}
+
+

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -103,7 +103,3 @@ ul {
     margin-left: 20px;
   }
 }
-
-
-
-

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -88,3 +88,22 @@ ul {
 .no-new-line {
   margin-bottom: 0;
 }
+
+#checkAnswersForm {
+  #checkAnswersTable {
+    margin-bottom: 30px;
+    th {
+      width: 290px;
+    }
+    td {
+      text-transform: capitalize;
+    }
+  }
+  a[href='/documents-check'] {
+    margin-left: 20px;
+  }
+}
+
+
+
+

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -17,7 +17,6 @@ module.exports = {
     checkNotNeededLocationPage: pagesPath('check-not-needed-location.js'),
     tenantInUkPage: pagesPath('tenant-in-uk.js'),
     checkConfirmedPage: pagesPath('check-confirmed.js'),
-    ukCheckYourselfPage: pagesPath('uk-check-yourself.js'),
     startPage: pagesPath('start.js'),
     checkNotNeededDatePage: pagesPath('check-not-needed-date.js'),
     personInPropertyPage: pagesPath('person-in-property.js'),

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "postinstall": "npm run build"
   },
   "dependencies": {
-    "1.0.2": "^1.0.0",
-    "codeceptjs": "^1.0.2",
     "hof": "^13.0.0",
     "hof-behaviour-address-lookup": "^1.1.0",
     "hof-build": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "postinstall": "npm run build"
   },
   "dependencies": {
+    "1.0.2": "^1.0.0",
+    "codeceptjs": "^1.0.2",
     "hof": "^13.0.0",
     "hof-behaviour-address-lookup": "^1.1.0",
     "hof-build": "^1.3.4",

--- a/test/unit/behaviours/rental-questions.js
+++ b/test/unit/behaviours/rental-questions.js
@@ -1,0 +1,181 @@
+'use strict';
+
+const reqres = require('reqres');
+const behaviour = require('../../../apps/right-to-rent-check/behaviours/rental-questions');
+
+describe('behaviours/rental-questions', () => {
+
+  class Base {
+    locals() {}
+  }
+
+  let sessionModel;
+  let controller;
+  let req;
+  let res;
+
+  it('exports a function', () => {
+    expect(behaviour).to.be.a('function');
+  });
+
+  describe('initialisation', () => {
+
+    it('returns a mixin', () => {
+      const Mixed = behaviour(Base);
+      expect(new Mixed()).to.be.an.instanceOf(Base);
+    });
+
+  });
+
+  describe('locals()', () => {
+
+    const superLocals = {
+      foo: 'bar'
+    };
+
+    const attrs = {
+      'documents-check': 'no',
+      'rental-property-location': 'england',
+      'property-address': '1 New Street, Town, ABC 123',
+      'tenant-in-uk': 'yes',
+      'tenancy-start': '2017-7-7',
+      'current-address': '1 Old Street, Ville, DEF 456'
+    };
+
+    let Behaviour;
+
+    beforeEach(() => {
+      sessionModel = {
+        toJSON: sinon.stub()
+      };
+
+      res = reqres.res();
+      req = reqres.req({
+        sessionModel,
+        translate: sinon.stub().returns('question')
+      });
+
+      req.translate.withArgs('pages.check-confirmed.table.documents').returns('documents');
+      req.translate.withArgs('pages.check-confirmed.table.where').returns('where');
+      req.translate.withArgs('pages.check-confirmed.table.address').returns('address');
+      req.translate.withArgs('pages.check-confirmed.table.persons').returns('status');
+      req.translate.withArgs('pages.check-confirmed.table.when').returns('tenancy-start');
+      req.translate.withArgs('pages.check-confirmed.table.uk').returns('uk');
+      req.translate.withArgs('pages.check-confirmed.table.current').returns('current');
+
+      sinon.stub(Base.prototype, 'locals').returns(superLocals);
+      Behaviour = behaviour(Base);
+      controller = new Behaviour();
+    });
+
+    afterEach(() => {
+      Base.prototype.locals.restore();
+    });
+
+    it('always returns questions and answers for documents, where, address, and living-status', () => {
+
+      req.sessionModel.toJSON.returns(attrs);
+
+      expect(controller.locals(req, res))
+        .to.have.property('questions')
+        .and.include.deep.members([{
+          question: 'documents',
+          answer: 'no'
+        }, {
+          question: 'where',
+          answer: 'england'
+        }, {
+          question: 'address',
+          answer: '1 New Street, Town, ABC 123'
+        }]);
+    });
+
+    describe('when the living-status is \'yes\'', () => {
+
+      it('also returns a question and answer for tenancy-start', () => {
+
+        req.sessionModel.toJSON.returns(Object.assign(attrs, {'living-status': 'yes'}));
+
+        expect(controller.locals(req, res))
+          .to.have.property('questions')
+          .and.deep.equal([{
+            question: 'documents',
+            answer: 'no'
+          }, {
+            question: 'where',
+            answer: 'england'
+          }, {
+            question: 'address',
+            answer: '1 New Street, Town, ABC 123'
+          }, {
+            question: 'status',
+            answer: 'yes'
+          }, {
+            question: 'tenancy-start',
+            answer: '7-7-2017'
+          }]);
+      });
+
+      it('does not return a question and answer for tenant-in-uk and current-address', () => {
+
+        req.sessionModel.toJSON.returns(Object.assign(attrs, {'living-status': 'yes'}));
+
+        expect(controller.locals(req, res))
+          .to.have.property('questions')
+          .and.not.include.deep.members([{
+            question: 'uk',
+            answer: 'yes'
+          }, {
+            question: 'current',
+            answer: '1 Old Street, Ville, DEF 456'
+          }]);
+      });
+
+    });
+
+    describe('when the living-status is \'no\'', () => {
+
+      it('also returns a question and answer for tenant-in-uk and current-address', () => {
+
+        req.sessionModel.toJSON.returns(Object.assign(attrs, {'living-status': 'no'}));
+
+        expect(controller.locals(req, res))
+          .to.have.property('questions')
+          .and.deep.equal([{
+            question: 'documents',
+            answer: 'no'
+          }, {
+            question: 'where',
+            answer: 'england'
+          }, {
+            question: 'address',
+            answer: '1 New Street, Town, ABC 123'
+          }, {
+            question: 'status',
+            answer: 'no'
+          }, {
+            question: 'uk',
+            answer: 'yes'
+          }, {
+            question: 'current',
+            answer: '1 Old Street, Ville, DEF 456'
+          }]);
+      });
+
+    });
+
+    it('does not return a question and answer for tenant-in-uk and current-address', () => {
+
+        req.sessionModel.toJSON.returns(Object.assign(attrs, {'living-status': 'no'}));
+
+        expect(controller.locals(req, res))
+          .to.have.property('questions')
+          .and.not.include.deep.members([{
+            question: 'tenancy-start',
+            answer: '7-7-2017'
+          }]);
+      });
+
+  });
+
+});

--- a/test/unit/behaviours/tenancy-start-postcode-check.test.js
+++ b/test/unit/behaviours/tenancy-start-postcode-check.test.js
@@ -59,38 +59,40 @@ describe('apps/behaviours/tenancy-start-postcode-check', () => {
     });
   });
   describe('saveValues()', () => {
-    let callback;
 
     beforeEach(() => {
-      callback = sinon.stub();
-      sinon.stub(Base.prototype, 'saveValues');
+      sinon.stub(Base.prototype, 'saveValues').yields();
     });
     afterEach(() => {
       Base.prototype.saveValues.restore();
     });
 
-    it('if the tenancyStart is after 2016-01-31 then do NOT unset valid-tenancy', () => {
+    it('if the tenancyStart is after 2016-01-31 then do NOT unset valid-tenancy', (done) => {
       req.form = {
         values: {
           'tenancy-start': '2017-01-01'
         }
       };
-      instance.saveValues(req, res, callback);
-      req.sessionModel.set.should.be.calledWith('valid-tenancy', true);
+      instance.saveValues(req, res, () => {
+        req.sessionModel.set.should.be.calledWith('valid-tenancy', true);
+        done();
+      });
     });
 
-    it('if the tenancyStart is before 2014-12-01 do NOT set valid-tenancy', () => {
+    it('if the tenancyStart is before 2014-12-01 do NOT set valid-tenancy', (done) => {
       req.form = {
         values: {
           'tenancy-start': '2012-01-01'
         }
       };
-      instance.saveValues(req, res, callback);
-      req.sessionModel.set.should.not.be.calledWith('valid-tenancy', true);
+      instance.saveValues(req, res, () => {
+        req.sessionModel.set.should.not.be.calledWith('valid-tenancy', true);
+        done();
+      });
     });
 
     describe('if the tenancyStart is between 2014-12-01 & 2016-01-31', () => {
-      it('the postcode is in the West Midlands, set valid-tenancy to true', () => {
+      it('the postcode is in the West Midlands, set valid-tenancy to true', (done) => {
         req.form = {
           values: {
             'tenancy-start': '2015-01-01'
@@ -98,12 +100,14 @@ describe('apps/behaviours/tenancy-start-postcode-check', () => {
         };
         req.sessionModel.get.withArgs('property-address-postcode').returns('B1 2EA');
 
-        instance.saveValues(req, res, callback);
-        req.sessionModel.set.should.be.calledWith('valid-tenancy', true);
+        instance.saveValues(req, res, () => {
+          req.sessionModel.set.should.be.calledWith('valid-tenancy', true);
+          done();
+        });
       });
 
       it(`if the tenancyStart is between 2014-12-01 & 2016-01-31 &
-        the postcode is NOT in the West Midlands do NOT set valid-tenancy to true`, () => {
+        the postcode is NOT in the West Midlands do NOT set valid-tenancy to true`, (done) => {
         req.form = {
           values: {
             'tenancy-start': '2015-01-01'
@@ -111,8 +115,10 @@ describe('apps/behaviours/tenancy-start-postcode-check', () => {
         };
         req.sessionModel.get.withArgs('property-address-postcode').returns('N1 2EA');
 
-        instance.saveValues(req, res, callback);
-        req.sessionModel.set.should.not.be.calledWith('valid-tenancy', true);
+        instance.saveValues(req, res, () => {
+          req.sessionModel.set.should.not.be.calledWith('valid-tenancy', true);
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
1) Add the /check-confirmed step to the user journey and conditionally
present one of two sets of tabular data dependning on the users'
previous selection.

2) Fix /tenancy-start by saving the post data to the sessionModel. 
This was required because the post data was needed in the view of the /check-confirmed step