### PR TITLE
Agent address page and steps

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/agent-address/address-step.js
+++ b/apps/right-to-rent-check/acceptance/features/agent-address/address-step.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const steps = require('../../../');
+const config = require('../../../../../config');
+const unknownPostcode = 'TN39TT';
+
+Feature('Given I am on the Address step of the Agent Address page');
+
+Before((
+  I,
+  agentAddressPage
+) => {
+  I.visitPage(agentAddressPage, steps);
+  I.fillField('#agent-address-postcode', unknownPostcode);
+  I.submitForm();
+});
+
+Scenario('When the address step loads then the change postcode link is visible', (
+  I
+) => {
+  I.seeNumberOfElements('.change-postcode', 1);
+});
+
+Scenario('When I click the Change postcode link then I am taken to the postcode step', (
+  I
+) => {
+  I.click('.change-postcode');
+  I.seeInCurrentUrl('?step=postcode');
+});
+
+Scenario('When the address step loads then the postcode I entered is visible', (
+  I
+) => {
+  I.see(unknownPostcode, 'span.postcode');
+});
+
+Scenario('When I do not enter an address and submit then I see an error', (
+  I
+) => {
+  I.submitForm();
+  I.seeErrors('#agent-address-group');
+});
+
+Scenario('When I submit an address then I am redirected to /landlord-name', (
+  I
+) => {
+  I.fillField('#agent-address', 'My address');
+  I.submitForm();
+  I.seeInCurrentUrl('landlord-name');
+});

--- a/apps/right-to-rent-check/acceptance/features/agent-address/lookup-step.js
+++ b/apps/right-to-rent-check/acceptance/features/agent-address/lookup-step.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const steps = require('../../../');
+const config = require('../../../../../config');
+
+Feature('Given I am on the Lookup step of the Agent Address page');
+
+Before((
+  I,
+  agentAddressPage
+) => {
+  I.visitPage(agentAddressPage, steps);
+  I.fillField('#agent-address-postcode', config.mocks.postcode);
+  I.submitForm();
+});
+
+Scenario('When I select an address and submit then I am taken to /landlord-name', (
+  I
+) => {
+  I.selectOption('#agent-address-select', config.mocks.address);
+  I.submitForm();
+  I.seeInCurrentUrl('landlord-name');
+});
+
+Scenario('When I do not select an address and submit then I see an error message', (
+  I
+) => {
+  I.submitForm();
+  I.seeErrors('#agent-address-select');
+});
+
+Scenario('When I click the Can\'t find address link then I am taken to the manual entry page', (
+  I
+) => {
+  I.click('.cant-find');
+  I.seeInCurrentUrl('agent-address?step=manual');
+});

--- a/apps/right-to-rent-check/acceptance/features/agent-address/manual-step.js
+++ b/apps/right-to-rent-check/acceptance/features/agent-address/manual-step.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const steps = require('../../../');
+const config = require('../../../../../config');
+
+Feature('Given I am on the Manual step of the Agent Address page');
+
+Before((
+  I,
+  agentAddressPage
+) => {
+  I.visitPage(agentAddressPage, steps);
+  I.click("a[href='?step=manual']");
+});
+
+Scenario('When the Manual step loads then the textarea element is visible', (
+  I
+) => {
+  I.seeElements('#agent-address');
+});
+
+Scenario('When the Manual step loads then the Change postcode link is not visible', (
+  I
+) => {
+  I.dontSee('.change-postcode');
+});
+
+Scenario('When the Manual step loads then the postcode I entered is not visible', (
+  I
+) => {
+  I.dontSee('span.postcode');
+});
+
+Scenario('When the Manual step loads then the info-message is not visible', (
+  I
+) => {
+  I.dontSee('.info-message');
+});

--- a/apps/right-to-rent-check/acceptance/features/agent-address/postcode-step.js
+++ b/apps/right-to-rent-check/acceptance/features/agent-address/postcode-step.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const steps = require('../../../');
+const config = require('../../../../../config');
+const unknownPostcode = 'TN39TT';
+const invalidPostcode = '123';
+const emptyPostcode = '';
+
+Feature('Given I am on the Agent Address page');
+
+Before((
+  I,
+  agentAddressPage
+) => {
+  I.visitPage(agentAddressPage, steps);
+});
+
+Scenario('When I click the Manually Address link then I am directed to enter my address on the manual step', (
+  I
+) => {
+  I.click('a[href="?step=manual"]')
+  I.seeInCurrentUrl('agent-address?step=manual');
+});
+
+Scenario('When I submit a valid postcode then I am directed to select my address from the lookup step', (
+  I
+) => {
+  I.fillField('#agent-address-postcode', config.mocks.postcode);
+  I.submitForm();
+  I.seeInCurrentUrl('agent-address?step=lookup');
+});
+
+Scenario('When I submit an Unkown postcode then I am directed to enter my address on the address step', (
+  I
+) => {
+  I.fillField('#agent-address-postcode', unknownPostcode);
+  I.submitForm();
+  I.seeInCurrentUrl('agent-address?step=address');
+});
+
+Scenario('When I submit an Invalid postcode then I see a postcode error message', (
+  I
+) => {
+  I.fillField('#agent-address-postcode', invalidPostcode);
+  I.submitForm();
+  I.seeInCurrentUrl('agent-address?step=postcode');
+  I.seeErrors('#agent-address-postcode');
+});
+
+Scenario('When I submit an Empty postcode then I see a postcode error message', (
+  I
+) => {
+  I.fillField('#agent-address-postcode', emptyPostcode);
+  I.submitForm();
+  I.seeInCurrentUrl('agent-address?step=postcode');
+  I.seeErrors('#agent-address-postcode');
+});
+

--- a/apps/right-to-rent-check/acceptance/features/agent-details.js
+++ b/apps/right-to-rent-check/acceptance/features/agent-details.js
@@ -45,15 +45,15 @@ Scenario('I see an error if I enter an invalid email address', (
   I.seeErrors(agentDetailsPage.fields.email);
 });
 
-Scenario('I am taken to the landlord-name step on a valid submission', (
+Scenario('I am taken to /agent-address on a valid submission', (
   I,
   agentDetailsPage,
-  landlordNamePage
+  agentAddressPage
 ) => {
   I.fillField(agentDetailsPage.fields.company, agentDetailsPage.content.company);
   I.fillField(agentDetailsPage.fields.name, agentDetailsPage.content.name);
   I.fillField(agentDetailsPage.fields.email, agentDetailsPage.content.email);
   I.fillField(agentDetailsPage.fields.phone, agentDetailsPage.content.phone);
   I.submitForm();
-  I.seeInCurrentUrl(landlordNamePage.url);
+  I.seeInCurrentUrl(agentAddressPage.url);
 });

--- a/apps/right-to-rent-check/acceptance/features/declaration-dynamic-content.js
+++ b/apps/right-to-rent-check/acceptance/features/declaration-dynamic-content.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const steps = require('../../');
+const config = require('../../../../config');
 
 Feature('Given I am on /landlord-agent');
 
@@ -41,6 +42,14 @@ Scenario('When I select agent and go through the agent part of the form Then I s
   I.fillField('#agent-email-address', 'b@g.com');
   I.fillField('#agent-phone-number', '0123');
   I.submitForm();
+
+  I.seeInCurrentUrl('agent-address');
+  I.fillField('#agent-address-postcode', config.mocks.postcode);
+  I.submitForm();
+  I.seeInCurrentUrl('agent-address?step=lookup');
+  I.selectOption('#agent-address-select', config.mocks.address);
+  I.submitForm();
+
   I.seeInCurrentUrl('landlord-name');
   I.fillField('#landlord-name-agent', 'Bruce Wayne');
   I.submitForm();

--- a/apps/right-to-rent-check/acceptance/features/tenant-in-uk.js
+++ b/apps/right-to-rent-check/acceptance/features/tenant-in-uk.js
@@ -35,9 +35,9 @@ Scenario('When I select Yes And submit the form Then I am taken to /current-prop
 
 Scenario('When I select No And submit the form Then I am taken to the /uk-check-yourself page', (
   I,
-  ukCheckYourselfPage
+  checkNotNeededUkPage
 ) => {
   I.click('#tenant-in-uk-no');
   I.submitForm();
-  I.seeInCurrentUrl(ukCheckYourselfPage.url);
+  I.seeInCurrentUrl(checkNotNeededUkPage.url);
 });

--- a/apps/right-to-rent-check/acceptance/pages/agent-address.js
+++ b/apps/right-to-rent-check/acceptance/pages/agent-address.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  url: 'agent-address'
+};

--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -169,6 +169,15 @@ module.exports = {
         'agent-email-address',
         'agent-phone-number'
       ],
+      next: '/agent-address'
+    },
+    '/agent-address': {
+      behaviours: AddressLookup({
+        addressKey: 'agent-address',
+        apiSettings: {
+          hostname: config.postcode.hostname
+        }
+      }),
       next: '/landlord-name'
     },
     '/landlord-name': {

--- a/apps/right-to-rent-check/translations/src/en/pages.json
+++ b/apps/right-to-rent-check/translations/src/en/pages.json
@@ -79,6 +79,9 @@
   "agent-details": {
     "header": "What are your contact details?"
   },
+  "agent-address": {
+    "header": "What is your address?"
+  },
   "confirm": {
     "header": "Placeholder page"
   },

--- a/apps/right-to-rent-check/translations/src/en/validation.json
+++ b/apps/right-to-rent-check/translations/src/en/validation.json
@@ -34,6 +34,16 @@
   "current-address": {
     "required": "Enter an address"
   },
+  "agent-address-postcode": {
+    "required": "Enter a postcode",
+    "postcode": "Enter a valid postcode"
+  },
+  "agent-address": {
+    "required": "Enter an address"
+  },
+  "agent-address-select": {
+    "required": "Select an address"
+  },
   "tenant-name": {
     "required": "Enter the prospective tenant's name"
   },

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -7,7 +7,7 @@ const pagesPath = page => path.resolve(__dirname,
 
 module.exports = {
   name: 'right-to-rent-check',
-  tests: './apps/**/acceptance/features/*.js',
+  tests: './apps/**/acceptance/features/**/*.js',
   include: {
     eligibilityCheckPage: pagesPath('eligibility-check.js'),
     documentCheckPage: pagesPath('documents-check.js'),
@@ -24,6 +24,7 @@ module.exports = {
     personLocationPage: pagesPath('person-location.js'),
     tenancyStartPage: pagesPath('tenancy-start-date.js'),
     agentDetailsPage: pagesPath('agent-details.js'),
+    agentAddressPage: pagesPath('agent-address.js'),
     landlordNamePage: pagesPath('landlord-name.js'),
     currentPropertyAddressPage: pagesPath('current-property-address.js'),
     tenantDetailsPage: pagesPath('tenant-details.js'),

--- a/config.js
+++ b/config.js
@@ -7,5 +7,9 @@ module.exports = {
     hostname: process.env.MOCK_POSTCODE === 'true' ?
       `http://${process.env.LISTEN_HOST || '0.0.0.0'}:${process.env.PORT || 8080}/api/postcode-test` :
       'https://postcodeinfo.service.justice.gov.uk'
+  },
+  mocks: {
+    postcode: 'CR0 2EU',
+    address: '49 Sydenham Road, Croydon, CR0 2EU'
   }
 };


### PR DESCRIPTION
Add a new page to capture the Agent's address using a postcode or manual address entry.

The button text will be amended to 'Find address' once `hof-behaviour-address-lookup` is amended to allow customisation of the button text.