### PR TITLE
Right to rent /confirm page and behaviour

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/check-confirmed.js
+++ b/apps/right-to-rent-check/acceptance/features/check-confirmed.js
@@ -26,8 +26,6 @@ Scenario('When I click the link then I am taken to /documents-check', (
   I.completeToStep(`/${checkConfirmedPage.url}`, {
     'documents-check': 'no',
     'rental-property-location': 'england',
-    'property-address-postcode': 'CR0 2EU',
-    'property-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
     'living-status': 'yes',
     'tenancy-start-day': '1',
     'tenancy-start-month': '1',
@@ -46,15 +44,15 @@ Scenario('When I click the Continue button then I see the start page', (
   I.seeInCurrentUrl('/start');
 });
 
-Scenario('When the user is living in the property then the following tabular data is visible', (
+Scenario('When the user is living in the property then the following data is visible', (
   I,
   checkConfirmedPage
 ) => {
   I.completeToStep(`/${checkConfirmedPage.url}`, {
     'documents-check': 'no',
     'rental-property-location': 'england',
-    'property-address-postcode': 'CR0 2EU',
-    'property-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
+    'rental-property-address-postcode': 'CR0 2EU',
+    'rental-property-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
     'living-status': 'yes',
     'tenancy-start-day': '1',
     'tenancy-start-month': '1',
@@ -68,19 +66,19 @@ Scenario('When the user is living in the property then the following tabular dat
   I.see('When did they move in 01-01-2017', '#checkAnswersTable tr:nth-child(5)');
 });
 
-Scenario('When the user is not living in the property then the following tabular data is visible', (
+Scenario('When the user is not living in the property then the following data is visible', (
   I,
   checkConfirmedPage
 ) => {
   I.completeToStep(`/${checkConfirmedPage.url}`, {
     'documents-check': 'no',
     'rental-property-location': 'england',
-    'property-address-postcode': 'CR0 2EU',
-    'property-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
+    'rental-property-address-postcode': 'CR0 2EU',
+    'rental-property-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
     'living-status': 'no',
     'tenant-in-uk': 'yes',
-    'current-address-postcode': 'CR0 2EU',
-    'current-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
+    'current-property-address-postcode': 'CR0 2EU',
+    'current-property-address-select': '49 Sydenham Road, Croydon, CR0 2EU',
   });
   I.seeNumberOfElements('#checkAnswersTable tr', 6);
   I.see('Does the person have documents No', '#checkAnswersTable tr:nth-child(1)');

--- a/apps/right-to-rent-check/acceptance/features/confirm/agent-in-property.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/agent-in-property.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const steps = require('../../../');
+
+Feature('Given I am an Agent and the tenant is living in the property');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/confirm', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'living-status': 'yes',
+    'tenancy-start-day': '1',
+    'tenancy-start-month': '1',
+    'tenancy-start-year': '2017',
+    'representative': 'agent'
+  });
+});
+
+
+Scenario('When the page loads at /confirm then I should see the start date', (
+  I
+) => {
+  I.see('2017-01-01', 'tr[data-id=\'tenancy-start\']');
+});
+
+Scenario('When the page loads at /confirm then I should not see their current address', (
+  I
+) => {
+  I.dontSeeElement('tr[data-id=\'current-property-address\']');
+});
+
+Scenario('When the page loads at /confirm then I should not see if they live in the UK', (
+  I
+) => {
+  I.dontSeeElement('tr[data-id=\'tenant-in-uk\']');
+});
+

--- a/apps/right-to-rent-check/acceptance/features/confirm/agent-not-in-property.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/agent-not-in-property.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const steps = require('../../../');
+
+Feature('Given I am an Agent and the tenant is not living in the property');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/confirm', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'living-status': 'no',
+    'tenant-in-uk': 'yes',
+    'current-property-address': 'ABC 222',
+    'representative': 'agent',
+    'agent-email-address': 'emma.ogrady@gmail.com'
+  });
+});
+
+Scenario('When the page at /confirm loads then I should see the tenants current address', (
+  I
+) => {
+  I.see('ABC 222', 'tr[data-id=\'current-property-address\']');
+});
+
+Scenario('When the page at /confirm loads then I should see the tenant lives in the UK', (
+  I
+) => {
+  I.see('Yes', 'tr[data-id=\'tenant-in-uk\']');
+});
+
+Scenario('When the page at /confirm loads then I should not see the moving-in date', (
+  I
+) => {
+  I.dontSeeElement('tr[data-id=\'tenancy-start\']');
+});
+

--- a/apps/right-to-rent-check/acceptance/features/confirm/agent.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/agent.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const steps = require('../../../');
+const add = (n) => {
+  return function () {
+    if (n != 0) {
+      n = n - 1
+      return 'yes'
+    }
+    return 'no';
+  }
+};
+
+Feature('Given I am an Agent');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/confirm', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'rental-property-address': 'CR0 2EU',
+    'living-status': 'no',
+    'tenant-in-uk': 'yes',
+    'current-property-address': 'CR0 2EU',
+    'tenant-add-another': add(2),
+    'representative': 'agent',
+    'agent-company': 'abc corp',
+    'agent-name': 'abc',
+    'agent-email-address': 'abc@abc-corp.com',
+    'agent-phone-number': '12345',
+    'agent-address': 'CR0 2EU',
+    'landlord-name-agent': 'Johnny',
+    'landlord-address-postcode': 'CR0 2EU'
+  });
+});
+
+Scenario('When /confirm loads then I should see Tenant details for each tenant', (
+  I
+) => {
+  I.seeInCurrentUrl('/confirm');
+  I.seeNumberOfElements('table[data-section=\'tenant-details\']', 1);
+  I.seeNumberOfElements('tbody[data-group=\'tenants\']', 2);
+
+  I.seeNumberOfElements('tr[data-id=\'tenant-name\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-dob\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-country\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-reference-number\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-passport-number\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-brp-number\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-recorded-delivery-number\']', 2);
+});
+
+Scenario('When /confirm loads then I should see the Agent Details', (
+  I
+) => {
+  I.seeInCurrentUrl('/confirm');
+  I.seeNumberOfElements('table[data-section=\'agent-details\']', 1);
+  I.see('abc corp', 'tr[data-id=\'agent-company\']');
+  I.see('abc', 'tr[data-id=\'agent-name\']');
+  I.see('abc@abc-corp.com', 'tr[data-id=\'agent-email-address\']');
+  I.see('12345', 'tr[data-id=\'agent-phone-number\']');
+  I.see('CR0 2EU', 'tr[data-id=\'agent-address\']');
+});
+
+Scenario('When /confirm loads then I should see the Landlord Details', (
+  I
+) => {
+  I.seeInCurrentUrl('/confirm');
+  I.seeNumberOfElements('table[data-section=\'landlord-details\']', 1);
+  I.see('Johnny', 'tr[data-id=\'landlord-name-agent\']');
+  I.see('CR0 2EU', 'tr[data-id=\'landlord-address\']');
+});
+
+Scenario('When /confirm loads then I should see the Key Details', (
+  I
+) => {
+  I.seeNumberOfElements('table[data-section=\'key-details\']', 1);
+  I.see('No', 'tr[data-id=\'documents-check\']');
+  I.see('England', 'tr[data-id=\'rental-property-location\']');
+  I.see('CR0 2EU', 'tr[data-id=\'rental-property-address\']');
+  I.see('No', 'tr[data-id=\'living-status\']');
+  I.see('Yes', 'tr[data-id=\'tenant-in-uk\']');
+  I.see('CR0 2EU', 'tr[data-id=\'current-property-address\']');
+});
+
+Scenario('When the Key Details load then they should not be edittable', (
+  I
+) => {
+  I.seeNumberOfElements('table[data-section=\'key-details\']', 1);
+  I.dontSee('Change', 'tr[data-id=\'documents-check\']');
+  I.dontSee('Change', 'tr[data-id=\'rental-property-location\']');
+  I.dontSee('Change', 'tr[data-id=\'rental-property-address\']');
+  I.dontSee('Change', 'tr[data-id=\'living-status\']');
+  I.dontSee('Change', 'tr[data-id=\'tenant-in-uk\']');
+  I.dontSee('Change', 'tr[data-id=\'current-property-address\']');
+});
+
+Scenario('When I click Continue then I am taken to /declaration', (
+  I
+) => {
+  I.click('[type=\'submit\']');
+  I.seeInCurrentUrl('/declaration');
+});

--- a/apps/right-to-rent-check/acceptance/features/confirm/edit-a-tenant.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/edit-a-tenant.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const steps = require('../../../');
+const add = (n) => {
+  return function () {
+    if (n != 0) {
+      n = n - 1
+      return 'yes'
+    }
+    return 'no';
+  }
+};
+
+Feature('Given from /confirm I click to edit tenant-name and click the back link');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/confirm', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'rental-property-address': 'CR0 2EU',
+    'living-status': 'no',
+    'tenant-in-uk': 'yes',
+    'current-property-address': 'CR0 2EU',
+    'tenant-add-another': add(2),
+    'representative': 'agent',
+    'agent-company': 'abc corp',
+    'agent-name': 'abc',
+    'agent-email-address': 'abc@abc-corp.com',
+    'agent-phone-number': '12345',
+    'agent-address': 'CR0 2EU',
+    'landlord-name': 'Johnny',
+    'landlord-address-postcode': 'CR0 2EU'
+  });
+  I.click('#tenant-name-change');
+  I.seeInCurrentUrl('tenant-details/edit#tenant-name');
+  I.click('#step a');
+  I.seeInCurrentUrl('tenant-another/edit');
+});
+
+Scenario('When I continue to /confirm without adding another tenant then I see the same tenants', (
+  I
+) => {
+  I.checkOption('#tenant-add-another-no');
+  I.click('input[type=\'submit\']');
+  I.seeInCurrentUrl('/confirm');
+  I.seeNumberOfElements('table[data-section=\'tenant-details\']', 1);
+  I.seeNumberOfElements('tbody[data-group=\'tenants\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-name\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-dob\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-country\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-reference-number\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-passport-number\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-brp-number\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-recorded-delivery-number\']', 2);
+});

--- a/apps/right-to-rent-check/acceptance/features/confirm/landlord-in-property.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/landlord-in-property.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const steps = require('../../../');
+
+Feature('Given I am a landlord and the tenant is in the property');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/confirm', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'living-status': 'yes',
+    'tenancy-start-day': '1',
+    'tenancy-start-month': '1',
+    'tenancy-start-year': '2017',
+    'representative': 'landlord',
+    'landlord-email-address': 'abc@test.com'
+  });
+});
+
+Scenario('When the page loads at /confirm then I should see the start date', (
+  I
+) => {
+  I.see('2017-01-01', 'tr[data-id=\'tenancy-start\']');
+});
+
+Scenario('When the page loads at /confirm then I should not see their current address', (
+  I
+) => {
+  I.dontSeeElement('tr[data-id=\'current-property-address\']');
+});
+
+Scenario('When the page loads at /confirm then I should not see if they live in the UK', (
+  I
+) => {
+  I.dontSeeElement('tr[data-id=\'tenant-in-uk\']');
+});
+
+

--- a/apps/right-to-rent-check/acceptance/features/confirm/landlord-not-in-property.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/landlord-not-in-property.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const steps = require('../../../');
+
+Feature('Given I am a landlord and the tenant is not in the property');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/confirm', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'living-status': 'no',
+    'tenant-in-uk': 'yes',
+    'current-property-address': 'ABC 222',
+    'representative': 'landlord'
+  });
+});
+
+Scenario('When the page at /confirm loads then I should see their current address', (
+  I
+) => {
+  I.see('ABC 222', 'tr[data-id=\'current-property-address\']');
+});
+
+Scenario('When the page at /confirm loads then I should see if they live in the UK', (
+  I
+) => {
+  I.see('Yes', 'tr[data-id=\'tenant-in-uk\']');
+});
+
+Scenario('When the page at /confirm loads then I should not see the moving-in date', (
+  I
+) => {
+  I.dontSeeElement('tr[data-id=\'tenancy-start\']');
+});
+

--- a/apps/right-to-rent-check/acceptance/features/confirm/landlord.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/landlord.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const steps = require('../../../');
+const add = (n) => {
+  return function () {
+    if (n != 0) {
+      n = n - 1
+      return 'yes'
+    }
+    return 'no';
+  }
+};
+
+Feature('Given I am a landlord');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/confirm', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'rental-property-address': 'abc 111',
+    'living-status': 'no',
+    'tenant-in-uk': 'yes',
+    'current-property-address': 'abc 222',
+    'tenant-add-another': add(2),
+    'representative': 'landlord',
+    'landlord-name': 'Johnny',
+    'landlord-company': 'Johnny Corp',
+    'landlord-email-address': 'johnny@corp.com',
+    'landlord-phone-number': '1234567890'
+  });
+});
+
+Scenario('When /confirm loads then I should see Tenant details for each tenant', (
+  I
+) => {
+  I.seeInCurrentUrl('/confirm');
+  I.seeNumberOfElements('table[data-section=\'tenant-details\']', 1);
+  I.seeNumberOfElements('tbody[data-group=\'tenants\']', 2);
+
+  I.seeNumberOfElements('tr[data-id=\'tenant-name\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-dob\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-country\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-reference-number\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-passport-number\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-brp-number\']', 2);
+  I.seeNumberOfElements('tr[data-id=\'tenant-recorded-delivery-number\']', 2);
+});
+
+Scenario('When /confirm loads then I should see the Landlord Details', (
+  I
+) => {
+  I.seeInCurrentUrl('/confirm');
+  I.seeNumberOfElements('table[data-section=\'landlord-details\']', 1);
+  I.see('Johnny', 'tr[data-id=\'landlord-name\']');
+  I.see('Johnny Corp', 'tr[data-id=\'landlord-company\']');
+  I.see('johnny@corp.com', 'tr[data-id=\'landlord-email-address\']');
+  I.see('1234567890', 'tr[data-id=\'landlord-phone-number\']');
+});
+
+Scenario('When /confirm loads then I should see the Key Details', (
+  I
+) => {
+  I.seeNumberOfElements('table[data-section=\'key-details\']', 1);
+  I.see('No', 'tr[data-id=\'documents-check\']');
+  I.see('England', 'tr[data-id=\'rental-property-location\']');
+  I.see('abc 111', 'tr[data-id=\'rental-property-address\']');
+  I.see('No', 'tr[data-id=\'living-status\']');
+});
+
+Scenario('When the Key Details load then they should not be edittable', (
+  I
+) => {
+  I.seeNumberOfElements('table[data-section=\'key-details\']', 1);
+  I.dontSee('Change', 'tr[data-id=\'documents-check\']');
+  I.dontSee('Change', 'tr[data-id=\'rental-property-location\']');
+  I.dontSee('Change', 'tr[data-id=\'rental-property-address\']');
+  I.dontSee('Change', 'tr[data-id=\'living-status\']');
+  I.dontSee('Change', 'tr[data-id=\'tenant-in-uk\']');
+  I.dontSee('Change', 'tr[data-id=\'current-property-address\']');
+});
+
+Scenario('When I click Continue then I am taken to /declaration', (
+  I
+) => {
+  I.click('[type=\'submit\']');
+  I.seeInCurrentUrl('/declaration');
+});

--- a/apps/right-to-rent-check/acceptance/features/landlord-name.js
+++ b/apps/right-to-rent-check/acceptance/features/landlord-name.js
@@ -1,14 +1,25 @@
 'use strict';
 
-const steps = require('../../');
-
-Feature('Landlord\'s Name Step');
+Feature('Agent Landlord\'s Name Step');
 
 Before((
-  I,
-  landlordNamePage
+  I
 ) => {
-  I.visitPage(landlordNamePage, steps);
+  I.amOnPage('/');
+  I.completeToStep('/landlord-name', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'living-status': 'yes',
+    'tenancy-start-day': '1',
+    'tenancy-start-month': '1',
+    'tenancy-start-year': '2017',
+    'representative': 'agent',
+    'agent-company': 'abc corp',
+    'agent-name': 'abc',
+    'agent-email-address': 'abc@abc-corp.com',
+    'agent-phone-number': '12345',
+    'agent-address': 'CR0 2EU',
+  });
 });
 
 Scenario('The correct fields are on the page', (

--- a/apps/right-to-rent-check/acceptance/features/property-address.js
+++ b/apps/right-to-rent-check/acceptance/features/property-address.js
@@ -2,7 +2,7 @@
 
 const steps = require('../../');
 
-Feature('Property Address Page');
+Feature('Rental Property Address Page');
 
 Before((
   I,

--- a/apps/right-to-rent-check/acceptance/features/tenancy-start/tenancy-start-backlink-submit.js
+++ b/apps/right-to-rent-check/acceptance/features/tenancy-start/tenancy-start-backlink-submit.js
@@ -12,11 +12,11 @@ Before((
   I.amOnPage(propertyAddressPage.url);
   I.completeToStep(`/${tenancyStartPage.url}`, {
     'rental-property-location': 'england',
-    'property-address-postcode': 'B1 2EA',
+    'rental-property-address-postcode': 'B1 2EA',
     'living-status': 'yes'});
   I.fillField('#tenancy-start-day', '1');
   I.fillField('#tenancy-start-month', '1');
-  I.fillField('#tenancy-start-year', '2015');
+  I.fillField('#tenancy-start-year', '2017');
   I.submitForm();
   I.seeInCurrentUrl(checkConfirmedPage.url);
   I.click(checkConfirmedPage.backlink);
@@ -33,7 +33,7 @@ Scenario('When I submit a date between 1 Dec 2014 & 31st Jan 2016 & the postcode
   checkNotNeededDatePage
 ) => {
   I.completeToStep(`/${tenancyStartPage.url}`, {
-    'property-address-postcode': 'SW1P 4DF',
+    'rental-property-address-postcode': 'SW1P 4DF',
     'living-status': 'yes'});
   I.fillField('#tenancy-start-day', '1');
   I.fillField('#tenancy-start-month', '1');
@@ -42,13 +42,13 @@ Scenario('When I submit a date between 1 Dec 2014 & 31st Jan 2016 & the postcode
   I.seeInCurrentUrl(checkNotNeededDatePage.url);
 });
 
-Scenario('When I submit a date between 1 Dec 2014 & 31st Jan 2016 & the postcode is in the West Midlands Then I see the tenancy details page', (
+Scenario('When I submit a date & the postcode is in the West Midlands Then I see the tenancy details page', (
   I,
   tenancyStartPage,
   checkConfirmedPage
 ) => {
   I.completeToStep(`/${tenancyStartPage.url}`, {
-    'property-address-postcode': 'B1 2EA',
+    'rental-property-address-postcode': 'B1 2EA',
     'living-status': 'yes'});
   I.fillField('#tenancy-start-day', '1');
   I.fillField('#tenancy-start-month', '1');

--- a/apps/right-to-rent-check/acceptance/features/tenancy-start/tenancy-start-date.js
+++ b/apps/right-to-rent-check/acceptance/features/tenancy-start/tenancy-start-date.js
@@ -78,7 +78,7 @@ Scenario('I see an exit page when I enter a date between 1 Dec 2014 & 31st Jan 2
 ) => {
   I.completeToStep(`/${tenancyStartPage.url}`, {
     'rental-property-location': 'england',
-    'property-address-postcode': 'SW1P 4DF',
+    'rental-property-address-postcode': 'SW1P 4DF',
     'living-status': 'yes'});
   I.fillField('#tenancy-start-day', '1');
   I.fillField('#tenancy-start-month', '1');
@@ -94,11 +94,11 @@ Scenario('When I submit a valid date Then I am taken to the check confirmed page
 ) => {
   I.completeToStep(`/${tenancyStartPage.url}`, {
     'rental-property-location': 'england',
-    'property-address-postcode': 'B1 2EA',
+    'rental-property-address-postcode': 'B1 2EA',
     'living-status': 'yes'});
   I.fillField('#tenancy-start-day', '1');
   I.fillField('#tenancy-start-month', '1');
-  I.fillField('#tenancy-start-year', '2015');
+  I.fillField('#tenancy-start-year', '2017');
   I.submitForm();
   I.seeInCurrentUrl(checkConfirmedPage.url);
 });
@@ -110,7 +110,7 @@ Scenario('I can go to the next step when I enter a date after 31st Jan 2016, tha
 ) => {
   I.completeToStep(`/${tenancyStartPage.url}`, {
     'rental-property-location': 'england',
-    'property-address-postcode': 'SW1P 4DF',
+    'rental-property-address-postcode': 'SW1P 4DF',
     'living-status': 'yes'});
   I.fillField('#tenancy-start-day', '1');
   I.fillField('#tenancy-start-month', '1');
@@ -126,7 +126,7 @@ Scenario('I can go to the next step when I enter a date after 31st Jan 2016, tha
 ) => {
   I.completeToStep(`/${tenancyStartPage.url}`, {
     'rental-property-location': 'england',
-    'property-address-postcode': 'B1 2EA',
+    'rental-property-address-postcode': 'B1 2EA',
     'living-status': 'yes'});
   I.fillField('#tenancy-start-day', '1');
   I.fillField('#tenancy-start-month', '1');

--- a/apps/right-to-rent-check/acceptance/pages/current-property-address.js
+++ b/apps/right-to-rent-check/acceptance/pages/current-property-address.js
@@ -13,7 +13,7 @@ module.exports = {
 
   elements: {
     manualEntry: 'a[href="?step=manual"]',
-    address: '#current-address'
+    address: '#current-property-address'
   },
 
   content: {

--- a/apps/right-to-rent-check/acceptance/pages/property-address.js
+++ b/apps/right-to-rent-check/acceptance/pages/property-address.js
@@ -14,9 +14,9 @@ module.exports = {
   backlink: '#step a',
 
   id: {
-    postcode: '#property-address-postcode',
-    select: '#property-address-select',
-    address: '#property-address',
+    postcode: '#rental-property-address-postcode',
+    select: '#rental-property-address-select',
+    address: '#rental-property-address',
     manualLink: '[href="?step=manual"]',
     cantFind: '.cant-find',
     change: '.change-postcode'

--- a/apps/right-to-rent-check/behaviours/confirm-tenants.js
+++ b/apps/right-to-rent-check/behaviours/confirm-tenants.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const mix = require('mixwith').mix;
+const Behaviour = require('hof-behaviour-summary-page');
+const _ = require('lodash');
+
+const getValue = (value, field, translate) => {
+  const key = `fields.${field}.options.${value}.label`;
+  let result = translate(key);
+  if (result === key) {
+    result = value;
+  }
+  return result;
+};
+
+const findStep = (steps, field) => {
+  return _.findKey(steps, step => {
+    return step.fields && step.fields.indexOf(field) !== -1;
+  });
+};
+
+const isTruthy = (model, field) => {
+  field = typeof field === 'object' ? field.field : field;
+  const value = model.get(field);
+  return value !== '' && value !== null && value !== undefined;
+};
+
+module.exports = Base => class extends mix(Base).with(Behaviour) {
+
+  parseSections(req) {
+    const settings = req.form.options;
+    const sections = this.getSectionSettings(settings);
+    return Object.keys(sections)
+      .map(section => {
+        const fields = sections[section] || [];
+        return {
+          section: {
+            label: req.translate([
+              `pages.confirm.sections.${section}.header`,
+              `pages.${section}.header`
+            ]),
+            id: section
+          },
+          group: (() => {
+            if (fields.some(field => field.children)) {
+              return _.flatMap(fields, field =>
+                _.map(req.sessionModel.get(field.field), (val, index) => ({
+                  name: field.field,
+                  fields: this.getFields(fields, req, index)
+                }))
+              );
+            }
+            return [{
+              fields: this.getFields(fields, req)
+            }];
+          }).call()
+        };
+      }).filter(section => section.group.every(entity => entity.fields.length));
+  }
+
+  getFields(fields, req, childIndex) {
+    return _.flatten(fields.filter(field => isTruthy(req.sessionModel, field))
+      .map(field => this.getFieldData(field, req, childIndex))).filter(f => f.value);
+  }
+
+  getFieldData(key, req, childIndex) {
+    if (key.children) {
+      const children = req.sessionModel.get(key.field)[childIndex];
+      return _.flatMap([children], child => {
+        if (child[key.uuid]) {
+          key.id = child[key.uuid];
+        }
+        const fields = _.map(key.children, item => item.field || item);
+        const selected = _.pick(child, fields);
+
+        return _.map(selected, (val, id) => {
+          id = _.find(key.children, kid => kid.field === id) || id;
+          val = val || req.translate(req.form.options.nullValue);
+
+          return this.getData(id, req, val, key);
+        });
+      });
+    }
+    return this.getData(key, req);
+  }
+
+  getData(key, req, value, field) {
+    value = value || getValue(req.sessionModel.get(key), key, req.translate);
+    const settings = req.form.options;
+    if (typeof key === 'string') {
+      const data = {
+        label: req.translate([
+          `pages.confirm.fields.${key}.label`,
+          `fields.${key}.summary`,
+          `fields.${key}.label`,
+          `fields.${key}.legend`
+        ]),
+        value: value || req.translate(settings.nullValue) || settings.nullValue,
+        step: '/confirm',
+        field: key,
+        edit: true,
+      };
+      if (field && field.id) {
+        data.uuid = `/${field.id}`;
+      }
+      return data;
+    }
+    if (typeof key.field === 'string') {
+      const obj = Object.assign(this.getData(key.field, req, value, field), key);
+      if (typeof key.parse === 'function') {
+        obj.value = key.parse(obj.value);
+      }
+      obj.edit = typeof key.edit === 'boolean' ? key.edit : true;
+      return obj;
+    }
+    return {};
+  }
+
+  getValues(req, res, callback) {
+    super.getValues(req, res, (err, values) => {
+
+      const settings = req.form.options;
+      const sections = this.getSectionSettings(settings);
+
+      const sectionData = _.flatMap(Object.keys(sections), section => {
+        return sections[section].filter(field => {
+          return field.children && field.children.length;
+        });
+      });
+
+      let collection;
+      let metaData;
+      let model;
+
+      // an edit button has been clicked
+      if (req.params.action === 'edit') {
+
+        // redirect to the page the query field is on
+        values.redirectTo = findStep(req.form.options.steps, req.query.field);
+        values.redirectTo += `/edit#${req.query.field}`;
+
+        // if an id is set, this is a collection
+        if (req.params.id) {
+
+          metaData = _.find(sectionData, section =>
+            _.find(req.sessionModel.get(section.field), field =>
+              field[section.uuid] === req.params.id
+            )
+          );
+
+          collection = req.sessionModel.get(metaData.field);
+
+          model = _.find(collection, {[`${metaData.uuid}`]: req.params.id});
+
+          // remove the tenant from the values and additional details list
+          values = _.omit(values, metaData.children.concat(metaData.uuid));
+
+          if (model) {
+            // add the new model to the values
+            Object.assign(values, model);
+
+            // update any lists associated with the collection
+            metaData.lists.forEach(list => {
+              values[list.id] = _.reduce(list.fields, (result, field) => {
+                const name = field.name || field;
+                const id = field.id || name;
+                if (values[name]) {
+                  result.push(id);
+                }
+                return result;
+              }, []);
+            });
+          }
+        }
+      } else {
+        metaData = _.find(sectionData, section => values[section.uuid]);
+        if (metaData) {
+          collection = req.sessionModel.get((metaData || {}).field);
+          values = _.omit(values, 'redirectTo');
+          model = _.pick(values, metaData.children.concat(metaData.uuid));
+
+          // update the tenants
+          if (_.isEmpty(model) === false) {
+            collection.splice(_.findIndex(collection, {
+              [`${metaData.uuid}`]: values[metaData.uuid]
+            }), 1, model);
+          }
+          values[metaData.field] = collection;
+        }
+      }
+      req.sessionModel.set(values);
+      callback(err);
+    });
+  }
+
+  render(req, res, callback) {
+    const redirectTo = req.sessionModel.get('redirectTo');
+    if (redirectTo) {
+      req.sessionModel.unset('redirectTo');
+      this.emit('complete', req, res);
+      res.redirect(redirectTo);
+    } else {
+      super.render(req, res, callback);
+    }
+  }
+};

--- a/apps/right-to-rent-check/behaviours/rental-questions.js
+++ b/apps/right-to-rent-check/behaviours/rental-questions.js
@@ -20,7 +20,7 @@ module.exports = superclass => class extends superclass {
       answer: data['rental-property-location']
     }, {
       question: translate('pages.check-confirmed.table.address'),
-      answer: data['property-address']
+      answer: data['rental-property-address']
     }, {
       question: translate('pages.check-confirmed.table.persons'),
       answer: data['living-status']
@@ -37,7 +37,7 @@ module.exports = superclass => class extends superclass {
         answer: data['tenant-in-uk']
       }, {
         question: translate('pages.check-confirmed.table.current'),
-        answer: data['current-address']
+        answer: data['current-property-address']
       });
     }
 

--- a/apps/right-to-rent-check/behaviours/tenancy-start-postcode-check.js
+++ b/apps/right-to-rent-check/behaviours/tenancy-start-postcode-check.js
@@ -17,7 +17,7 @@ module.exports = superclass => class extends superclass {
   saveValues(req, res, next) {
     super.saveValues(req, res, err => {
       const tenancyStart = new Date(req.form.values['tenancy-start']).getTime();
-      const postcode = req.sessionModel.get('property-address-postcode');
+      const postcode = req.sessionModel.get('rental-property-address-postcode');
 
       if (inRange(tenancyStart)) {
         req.sessionModel.set('valid-tenancy', isPilotOrUndefined(postcode));

--- a/apps/right-to-rent-check/behaviours/tenants.js
+++ b/apps/right-to-rent-check/behaviours/tenants.js
@@ -49,9 +49,8 @@ module.exports = fields => {
 
         const edittedTenant = isEditted(tenants, tenant, values['tenant-uuid']);
 
-
         // when a user has selected the change button
-        if (req.params.action === 'edit') {
+        if (req.params.action === 'edit' && req.params.id) {
           // Find the tenant the user wants to edit
           tenant = _.find(tenants, {'tenant-uuid': req.params.id});
 
@@ -100,14 +99,11 @@ module.exports = fields => {
         // After a tenant record has been edittedTenant,
         // either by way of the back link or a 'change' link
         } else if (edittedTenant) {
-
           // make sure the replacer and values have the same uuids
           tenant['tenant-uuid'] = values['tenant-uuid'] = edittedTenant['tenant-uuid'];
-          tenant.edit = false;
           tenants.splice(_.findIndex(tenants, edittedTenant), 1, tenant);
 
         } else if (isNewTenant(tenants, tenant)) {
-
           tenant.edit = false;
           tenant['tenant-uuid'] = values['tenant-uuid'] = uuid();
           tenants.push(tenant);
@@ -120,14 +116,15 @@ module.exports = fields => {
         values.tenants = tenants;
 
         req.sessionModel.set(values);
-
         callback();
       });
     }
 
     saveValues(req, res, callback) {
-      req.sessionModel.unset(fields.concat('tenant-uuid', 'redirectTo'));
-      callback();
+      super.saveValues(req, res, (err) => {
+        req.sessionModel.unset(fields.concat('tenant-uuid', 'redirectTo'));
+        callback(err);
+      });
     }
 
     render(req, res, callback) {

--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -13,6 +13,7 @@ const tenants = require('./behaviours/tenants')([
   'tenant-brp-number',
   'tenant-recorded-delivery-number'
 ]);
+const confirmTenants = require('./behaviours/confirm-tenants.js');
 const getDeclarer = require('./behaviours/get-declarer');
 const rentalQuestions = require('./behaviours/rental-questions');
 const config = require('../../config');
@@ -52,7 +53,7 @@ module.exports = {
     '/rental-property-address': {
       behaviours: AddressLookup({
         required: true,
-        addressKey: 'property-address',
+        addressKey: 'rental-property-address',
         apiSettings: {
           hostname: config.postcode.hostname
         }
@@ -96,7 +97,7 @@ module.exports = {
     },
     '/current-property-address': {
       behaviours: AddressLookup({
-        addressKey: 'current-address',
+        addressKey: 'current-property-address',
         apiSettings: {
           hostname: config.postcode.hostname
         }
@@ -202,6 +203,79 @@ module.exports = {
       next: '/confirm'
     },
     '/confirm': {
+      behaviours: [confirmTenants, 'complete'],
+      nullValue: 'pages.tenant-another.tables.values.undefined',
+      sections: {
+        'key-details': [{
+            field: 'documents-check',
+            edit: false
+          }, {
+            field: 'rental-property-location',
+            edit: false
+          }, {
+            field: 'rental-property-address',
+            edit: false
+          }, {
+            field: 'living-status',
+            edit: false
+          }, {
+            field: 'tenant-in-uk',
+            edit: false
+          }, {
+            field: 'current-property-address',
+            edit: false
+          }, {
+            field: 'tenancy-start',
+            edit: false
+          }
+        ],
+        'tenant-details': [
+          {
+            field: 'tenants',
+            children: [
+              'tenant-name',
+              'tenant-dob',
+              'tenant-country',
+              'tenant-reference-number',
+              'tenant-passport-number',
+              'tenant-brp-number',
+              'tenant-recorded-delivery-number'
+            ],
+            uuid: 'tenant-uuid',
+            lists: [{
+              id: 'tenant-additional-details',
+              fields: [{
+                name: 'tenant-reference-number',
+                id: 'reference-number'
+              }, {
+                name: 'tenant-passport-number',
+                id: 'passport-number'
+              }, {
+                name: 'tenant-brp-number',
+                id: 'brp-number'
+              }, {
+                name: 'tenant-recorded-delivery-number',
+                id: 'recorded-delivery-number'
+              }]
+            }]
+          }
+        ],
+        'agent-details': [
+          'agent-company',
+          'agent-name',
+          'agent-email-address',
+          'agent-phone-number',
+          'agent-address'
+        ],
+        'landlord-details': [
+          'landlord-name',
+          'landlord-name-agent',
+          'landlord-company',
+          'landlord-email-address',
+          'landlord-phone-number',
+          'landlord-address'
+        ]
+      },
       next: '/declaration'
     },
     '/declaration': {

--- a/apps/right-to-rent-check/translations/src/en/pages.json
+++ b/apps/right-to-rent-check/translations/src/en/pages.json
@@ -97,8 +97,56 @@
   "agent-address": {
     "header": "What is your address?"
   },
+  "check-your-answers": {
+    "header": "Check your answers"
+  },
   "confirm": {
-    "header": "Placeholder page"
+    "sections": {
+      "key-details": {
+        "header": "Key details"
+      },
+      "tenant-details": {
+        "header": "Tenant details"
+      },
+      "agent-details": {
+        "header": "Agent details"
+      },
+      "landlord-details": {
+        "header": "Landlord details"
+      }
+    },
+    "fields": {
+      "documents-check": {
+        "label": "Does the person have documents?"
+      },
+      "rental-property-location": {
+        "label": "Rental property location"
+      },
+      "rental-property-address": {
+        "label": "Rental property address"
+      },
+      "living-status": {
+        "label": "Person(s) living in property"
+      },
+      "tenant-in-uk": {
+        "label": "Person(s) living in UK"
+      },
+      "current-property-address": {
+        "label": "Current address"
+      },
+      "tenancy-start": {
+        "label": "When did they move in?"
+      },
+      "tenant-name": {
+        "label": "Tenant name"
+      },
+      "agent-address": {
+        "label": "Address"
+      },
+      "landlord-address": {
+        "label": "Address"
+      }
+    }
   },
   "declaration": {
     "header": "Declaration",

--- a/apps/right-to-rent-check/views/confirm.html
+++ b/apps/right-to-rent-check/views/confirm.html
@@ -1,0 +1,21 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#rows}}
+      <h3>{{section.label}}</h3>
+      <table data-section="{{section.id}}" class="table-details">
+        {{#group}}
+        <tbody{{#name}} data-group="{{name}}"{{/name}}>
+          {{#fields}}
+            <tr data-id="{{field}}">
+              <td data-label="{{label}}">{{label}}</td>
+              <td data-value="{{value}}">{{value}}</td>
+              <td>{{#edit}}<a href="{{step}}/edit{{uuid}}?field={{field}}" class="button-change" id="{{field}}-change">{{#t}}buttons.change{{/t}}</a>{{/edit}}</td>
+            </tr>
+          {{/fields}}
+        </tbody>
+        {{/group}}
+      </table>
+    {{/rows}}
+    {{#input-submit}}confirm{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -79,6 +79,17 @@ table.tenant-details {
   }
 }
 
+table.table-details {
+  tbody[data-group='tenants'] {
+    display: table;
+    margin-bottom: 2em;
+    width: 100%;
+    &:last-child {
+      margin-bottom: 0px;
+    }
+  }
+}
+
 ul {
   @extend .text;
   @extend .list;

--- a/mock-postcode.js
+++ b/mock-postcode.js
@@ -10,8 +10,15 @@ module.exports = router.use('/api/postcode-test/:action?/:postcode?', (req, res)
   const postcode = decodeURIComponent(req.params.postcode);
   if (action === 'addresses') {
     if (req.query.postcode === 'CR0 2EU') {
+      res.send(JSON.stringify([{
       // eslint-disable-next-line camelcase
-      res.send(JSON.stringify([{formatted_address: '49 Sydenham Road\nCroydon\nCR0 2EU', postcode: 'CR0 2EU'}]));
+        formatted_address: '49 Sydenham Road\nCroydon\nCR0 2EU', postcode: 'CR0 2EU'
+      }]));
+    } else if (req.query.postcode === 'B1 2EA') {
+      res.send(JSON.stringify([{
+      // eslint-disable-next-line camelcase
+        formatted_address: '1 Broad Street\nBirmingham\nWest Midlands\nB1 2EA', postcode: 'B1 2EA'
+      }]));
     } else {
       res.setHeader('Content-Type', 'application/json');
       res.send(JSON.stringify([]));

--- a/package.json
+++ b/package.json
@@ -17,13 +17,16 @@
   "dependencies": {
     "hof": "^13.0.0",
     "hof-behaviour-address-lookup": "^2.1.1",
+    "hof-behaviour-summary-page": "^3.0.0",
     "hof-build": "^1.3.4",
     "hof-component-date": "^1.4.0",
+    "hof-form-controller": "^5.1.0",
     "hof-frontend-toolkit": "^2.1.0",
     "hof-theme-govuk": "^4.0.0",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.1.1",
     "lodash": "^4.17.4",
+    "mixwith": "^0.1.1",
     "moment": "^2.18.1",
     "typeahead-aria": "^1.0.4",
     "uuid": "^3.1.0"

--- a/test/unit/behaviours/confirm-tenants.js
+++ b/test/unit/behaviours/confirm-tenants.js
@@ -1,0 +1,452 @@
+'use strict';
+
+const reqres = require('reqres');
+const behaviour = require('../../../apps/right-to-rent-check/behaviours/confirm-tenants');
+
+describe('behaviours/confirm-tenants', () => {
+
+  class Base {
+    render() {}
+    getValues() {}
+    emit() {}
+  }
+
+  let req;
+  let res;
+  let get;
+  let Behaviour;
+  let controller;
+
+  const sections = {
+    'foo': [{
+      field: 'foo-name',
+      edit: false
+    }, {
+      field: 'foo-email',
+      edit: false
+    }],
+    'baz-details': [
+      {
+        field: 'baz',
+        children: [
+          'name',
+          'dob',
+          'country'
+        ],
+        uuid: 'baz-uuid',
+        lists: [{
+          id: 'additional-details',
+          fields: [{
+            name: 'reference-number',
+            id: 'ref-number'
+          },
+            'passport-number',
+            'brp-number',
+          {
+            name: 'recorded-delivery-number',
+            id: 'delivery-number'
+          }]
+        }]
+      }
+    ],
+    'bar': [
+      'bar-name',
+      'bar-dob'
+    ]
+  };
+
+  const options = {
+    steps: {
+      '/step-a': {
+        fields: [
+          'foo-name',
+          'foo-email'
+        ]
+      },
+      '/step-b': {
+        fields: [
+          'name',
+          'dob',
+          'country'
+        ]
+      },
+      '/step-c': {
+        fields: [
+          'bar-name',
+          'bar-dob'
+        ]
+      },
+      '/confirm': {
+        sections: sections
+      }
+    },
+    sections: sections
+  };
+
+  it('exports a function', () => {
+    expect(behaviour).to.be.a('function');
+  });
+
+  describe('initialisation', () => {
+
+    it('returns a mixin', () => {
+      const Mixed = behaviour(Base);
+      expect(new Mixed({
+        a: 'b'
+      })).to.be.an.instanceOf(Base);
+    });
+
+  });
+
+  describe('parseSections()', () => {
+
+    const translate = sinon.stub();
+
+    translate.withArgs([
+      'pages.confirm.sections.foo.header',
+      'pages.foo.header'
+    ]).returns('Foo');
+    translate.withArgs([
+      'pages.confirm.sections.bar.header',
+      'pages.bar.header'
+    ]).returns('Bar');
+    translate.withArgs([
+      'pages.confirm.sections.baz-details.header',
+      'pages.baz-details.header'
+    ]).returns('Baz details');
+    translate.withArgs([
+      'pages.confirm.fields.name.label',
+      'fields.name.summary',
+      'fields.name.label',
+      'fields.name.legend'
+    ]).returns('Name');
+    translate.withArgs([
+      'pages.confirm.fields.dob.label',
+      'fields.dob.summary',
+      'fields.dob.label',
+      'fields.dob.legend'
+    ]).returns('Date of birth');
+    translate.withArgs([
+      'pages.confirm.fields.country.label',
+      'fields.country.summary',
+      'fields.country.label',
+      'fields.country.legend'
+    ]).returns('Country of nationality');
+
+     translate.withArgs([
+      'pages.confirm.fields.foo-name.label',
+      'fields.foo-name.summary',
+      'fields.foo-name.label',
+      'fields.foo-name.legend'
+    ]).returns('Foo name');
+    translate.withArgs([
+      'pages.confirm.fields.foo-email.label',
+      'fields.foo-email.summary',
+      'fields.foo-email.label',
+      'fields.foo-email.legend'
+    ]).returns('Foo email');
+    translate.withArgs([
+      'pages.confirm.fields.bar-name.label',
+      'fields.bar-name.summary',
+      'fields.bar-name.label',
+      'fields.bar-name.legend'
+    ]).returns('Bar name');
+    translate.withArgs([
+      'pages.confirm.fields.bar-dob.label',
+      'fields.bar-dob.summary',
+      'fields.bar-dob.label',
+      'fields.bar-dob.legend'
+    ]).returns('Bar date of birth');
+
+    translate
+      .withArgs('fields.foo-name.options.linda.label')
+      .returns('linda');
+    translate
+      .withArgs('fields.foo-email.options.linda@test.com.label')
+        .returns('linda@test.com');
+    translate
+      .withArgs('fields.bar-name.options.denis.label')
+      .returns('denis');
+    translate
+      .withArgs('fields.bar-dob.options.1980-01-01.label')
+      .returns('1980-01-01');
+
+    get = sinon.stub();
+    get.withArgs('baz').returns([{
+      'name': 'john',
+      'dob': '1980-01-01',
+      'country': 'Qatar'
+    }]);
+    get.withArgs('foo-name').returns('linda');
+    get.withArgs('foo-email').returns('linda@test.com');
+    get.withArgs('bar-name').returns('denis');
+    get.withArgs('bar-dob').returns('1980-01-01');
+
+    beforeEach(() => {
+      res = reqres.res();
+      req = reqres.req({
+        form: {options},
+        translate: translate,
+        sessionModel: {get: get}
+      });
+      Behaviour = behaviour(Base);
+      controller = new Behaviour();
+    });
+
+    it('returns a section groups and fields for each section', () => {
+      expect(controller.parseSections(req)).to.deep.equal([{
+        group: [{
+          fields: [{
+            field: 'foo-name',
+            edit: false,
+            step: '/confirm',
+            value: 'linda',
+            label: 'Foo name'
+          }, {
+            field: 'foo-email',
+            edit: false,
+            step: '/confirm',
+            value: 'linda@test.com',
+            label: 'Foo email'
+          }]
+        }],
+        section: {
+          id: 'foo',
+          label: 'Foo'
+        }
+      }, {
+        group: [{
+          name: 'baz',
+          fields: [{
+            field: 'name',
+            edit: true,
+            step: '/confirm',
+            value: 'john',
+            label: 'Name'
+          }, {
+            field: 'dob',
+            edit: true,
+            step: '/confirm',
+            value: '1980-01-01',
+            label: 'Date of birth'
+          }, {
+            field: 'country',
+            edit: true,
+            step: '/confirm',
+            value: 'Qatar',
+            label: 'Country of nationality'
+          }]
+        }],
+        section: {
+          id: 'baz-details',
+          label: 'Baz details'
+        }
+      }, {
+        group: [{
+          fields: [{
+            field: 'bar-name',
+            edit: true,
+            step: '/confirm',
+            value: 'denis',
+            label: 'Bar name'
+          }, {
+            field: 'bar-dob',
+            edit: true,
+            step: '/confirm',
+            value: '1980-01-01',
+            label: 'Bar date of birth'
+          }]
+        }],
+        section: {
+          id: 'bar',
+          label: 'Bar'
+        }
+      }]);
+    });
+  });
+
+  describe('render()', () => {
+
+    const callback = sinon.stub();
+
+    beforeEach(() => {
+      res = reqres.res();
+      req = reqres.req({
+        form: {options},
+        sessionModel: {
+          get: get,
+          unset: sinon.stub()
+        }
+      });
+      sinon.stub(Base.prototype, 'render');
+      sinon.stub(Base.prototype, 'emit');
+      Behaviour = behaviour(Base);
+      controller = new Behaviour();
+    });
+
+    afterEach(() => {
+      Base.prototype.render.restore();
+      Base.prototype.emit.restore();
+    });
+
+    describe('when redirectTo is not set', () => {
+      it('calls the parent method', () => {
+        controller.render(req, res, callback);
+        expect(Base.prototype.render).to.have.been.calledWith(req, res, callback);
+      });
+    });
+
+    describe('when redirectTo is set', () => {
+      const redirectTo = '/test';
+
+      it('unsets redirectTo from the model', () => {
+        req.sessionModel.get.withArgs('redirectTo').returns(redirectTo);
+        controller.render(req, res, callback);
+        expect(req.sessionModel.unset).to.have.been.calledWith('redirectTo');
+      });
+
+      it('emits a complete event', () => {
+        req.sessionModel.get.withArgs('redirectTo').returns(redirectTo);
+        controller.render(req, res, callback);
+        expect(Base.prototype.emit).to.have.been.calledWith('complete', req, res);
+      });
+
+      it('redirects to redirectTo', () => {
+        req.sessionModel.get.withArgs('redirectTo').returns(redirectTo);
+        controller.render(req, res, callback);
+        expect(res.redirect).to.have.been.calledWith(redirectTo);
+      });
+
+    });
+
+  });
+
+  describe('getValues()', () => {
+
+    const values = {
+      name: 'baz a',
+      dob: '1980-01-01',
+      country: 'uk',
+      'baz-uuid': '1234567890',
+      'reference-number': 'abc123',
+      'recorded-delivery-number': '123xyz',
+      'passport-number': '11111111'
+    };
+
+    beforeEach(() => {
+      get.withArgs('baz').returns([{
+        name: 'baz a',
+        dob: '1970-01-01',
+        country: 'uk',
+        'baz-uuid': '1234567890'
+      }, {
+        name: 'baz b',
+        dob: '1999-01-01',
+        country: 'uk',
+        'baz-uuid': '0987654321'
+      }]);
+      res = reqres.res();
+      req = reqres.req({
+        form: {options},
+        sessionModel: {
+          get: get,
+          set: sinon.stub()
+        }
+      });
+      sinon.stub(Base.prototype, 'getValues').yields(null, values);
+      Behaviour = behaviour(Base);
+      controller = new Behaviour();
+    });
+
+    afterEach(() => {
+      Base.prototype.getValues.restore();
+    });
+
+    describe('when editting', () => {
+
+      it('a redirectTo path property is set on values', (done) => {
+        req.params.action = 'edit';
+        req.query.field = 'bar-name';
+        controller.getValues(req, res, (err) => {
+          expect(err).to.not.exist;
+          expect(req.sessionModel.set.args[0][0]).to.include({
+            redirectTo: '/step-c/edit#bar-name'
+          });
+          done();
+        });
+      });
+
+      it('a model is merged with the values if the params id matches a model\'s id', (done) => {
+        req.params.action = 'edit';
+        req.params.id = '1234567890';
+        req.query.field = 'bar-name';
+        controller.getValues(req, res, (err) => {
+          expect(err).to.not.exist;
+          expect(req.sessionModel.set.args[0][0]).to.include({
+            name: 'baz a',
+            dob: '1970-01-01',
+            'baz-uuid': '1234567890'
+          });
+          done();
+        });
+      });
+
+      it('creates a list for each collection with checkboxes', (done) => {
+        req.params.action = 'edit';
+        req.params.id = '1234567890';
+        req.query.field = 'bar-name';
+        controller.getValues(req, res, (err) => {
+          expect(err).to.not.exist;
+          expect(req.sessionModel.set.args[0][0]['additional-details']).to.deep.equal([
+            'ref-number',
+            'passport-number',
+            'delivery-number'
+          ]);
+          done();
+        });
+      });
+
+    });
+
+    describe('when loading', () => {
+
+      it('the collections are updated with the appropriate values', (done) => {
+        controller.getValues(req, res, (err) => {
+          expect(err).to.not.exist;
+          expect(req.sessionModel.set).to.have.been.calledWith({
+            name: 'baz a',
+            dob: '1980-01-01',
+            country: 'uk',
+            'baz-uuid': '1234567890',
+            'recorded-delivery-number': '123xyz',
+            'reference-number': 'abc123',
+            'passport-number': '11111111',
+            baz: [{
+              name: 'baz a',
+              dob: '1980-01-01',
+              country: 'uk',
+              'baz-uuid': '1234567890'
+            }, {
+              name: 'baz b',
+              dob: '1999-01-01',
+              country: 'uk',
+             'baz-uuid': '0987654321'
+            }]
+          });
+          done();
+        });
+      });
+
+      it('the property is removed from the values', (done) => {
+        controller.getValues(req, res, (err) => {
+          expect(err).to.not.exist;
+          expect(req.sessionModel.set.args[0][0].redirectTo).to.not.exist;
+          done();
+        });
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/behaviours/rental-questions.js
+++ b/test/unit/behaviours/rental-questions.js
@@ -36,10 +36,10 @@ describe('behaviours/rental-questions', () => {
     const attrs = {
       'documents-check': 'no',
       'rental-property-location': 'england',
-      'property-address': '1 New Street, Town, ABC 123',
+      'rental-property-address': '1 New Street, Town, ABC 123',
       'tenant-in-uk': 'yes',
       'tenancy-start': '2017-7-7',
-      'current-address': '1 Old Street, Ville, DEF 456'
+      'current-property-address': '1 Old Street, Ville, DEF 456'
     };
 
     let Behaviour;

--- a/test/unit/behaviours/tenancy-start-postcode-check.test.js
+++ b/test/unit/behaviours/tenancy-start-postcode-check.test.js
@@ -98,7 +98,7 @@ describe('apps/behaviours/tenancy-start-postcode-check', () => {
             'tenancy-start': '2015-01-01'
           }
         };
-        req.sessionModel.get.withArgs('property-address-postcode').returns('B1 2EA');
+        req.sessionModel.get.withArgs('rental-property-address-postcode').returns('B1 2EA');
 
         instance.saveValues(req, res, () => {
           req.sessionModel.set.should.be.calledWith('valid-tenancy', true);
@@ -113,7 +113,7 @@ describe('apps/behaviours/tenancy-start-postcode-check', () => {
             'tenancy-start': '2015-01-01'
           }
         };
-        req.sessionModel.get.withArgs('property-address-postcode').returns('N1 2EA');
+        req.sessionModel.get.withArgs('rental-property-address-postcode').returns('N1 2EA');
 
         instance.saveValues(req, res, () => {
           req.sessionModel.set.should.not.be.calledWith('valid-tenancy', true);

--- a/test/unit/behaviours/tenants.js
+++ b/test/unit/behaviours/tenants.js
@@ -140,7 +140,7 @@ describe('behaviours/tenants', () => {
       ];
       res = reqres.res();
       req = reqres.req({sessionModel});
-      sinon.stub(Base.prototype, 'saveValues');
+      sinon.stub(Base.prototype, 'saveValues').yields();
       Tenants = Behaviour(fields)(Base);
       controller = new Tenants();
     });
@@ -150,7 +150,8 @@ describe('behaviours/tenants', () => {
     });
 
     it('unsets all fields and the tenant-uuid from the session', (done) => {
-      controller.saveValues(req, res, () => {
+      controller.saveValues(req, res, (err) => {
+        expect(err).to.not.exist;
         expect(sessionModel.unset)
           .to.have.been.calledWithExactly(fields.concat('tenant-uuid', 'redirectTo'));
         done();
@@ -585,8 +586,7 @@ describe('behaviours/tenants', () => {
           }, {
             'tenant-name': 'Angel Ragwort',
             'tenant-age': '39',
-            'tenant-uuid': '0987654321',
-            'edit': false
+            'tenant-uuid': '0987654321'
           }]
         };
 


### PR DESCRIPTION
Add a behaviour that extends the hof-behaviour-summary-page
with the ability to declare fields with children for the scenario
where a field may be saved as a collection

This is an image of how the tenants will be rendered.

![image](https://user-images.githubusercontent.com/1274835/31488712-8c68ce0e-af36-11e7-94f4-786f1c62e1e0.png)
