### PR TITLE
Fix unreliability of agent-not-in-property acceptance

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/confirm/agent-not-in-property.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/agent-not-in-property.js
@@ -13,7 +13,7 @@ Before((
     'rental-property-location': 'england',
     'living-status': 'no',
     'tenant-in-uk': 'yes',
-    'current-property-address': 'ABC 222',
+    'current-property-address-postcode': 'CR0 2EU',
     'representative': 'agent',
     'agent-email-address': 'emma.ogrady@gmail.com'
   });
@@ -22,7 +22,7 @@ Before((
 Scenario('When the page at /confirm loads then I should see the tenants current address', (
   I
 ) => {
-  I.see('ABC 222', 'tr[data-id=\'current-property-address\']');
+  I.see('CR0 2EU', 'tr[data-id=\'current-property-address\']');
 });
 
 Scenario('When the page at /confirm loads then I should see the tenant lives in the UK', (


### PR DESCRIPTION
* This causing the tests to fail
~~Sometimes this tests keeps the address data from a previous test because~~
The completeToStep method can go through various routes for the address, this test assumes it will take the user through the manual address step.  This is not always going to happen, sometimes it does an address lookup with `Cr0 2eu`.  Force the test to go through the postcode lookup step