### PR TITLE
Update to hof-behaviour-address-lookup to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "hof": "^13.0.0",
-    "hof-behaviour-address-lookup": "^2.1.1",
     "hof-behaviour-emailer": "^2.2.0",
+    "hof-behaviour-address-lookup": "^2.2.0",
     "hof-behaviour-summary-page": "^3.0.0",
     "hof-build": "^1.5.0",
     "hof-component-date": "^1.4.0",


### PR DESCRIPTION
Fix backLink address lookup