### PR TITLE
Make date formats a configurable parameter

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/confirm/agent-in-property.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/agent-in-property.js
@@ -29,7 +29,7 @@ Before((
 Scenario('When the page loads at /confirm then I should see the start date', (
   I
 ) => {
-  I.see('2017-01-01', 'tr[data-id=\'tenancy-start\']');
+  I.see('01-01-2017', 'tr[data-id=\'tenancy-start\']');
 });
 
 Scenario('When the page loads at /confirm then I should not see their current address', (

--- a/apps/right-to-rent-check/acceptance/features/confirm/landlord-in-property.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/landlord-in-property.js
@@ -26,7 +26,7 @@ Before((
 Scenario('When the page loads at /confirm then I should see the start date', (
   I
 ) => {
-  I.see('2017-01-01', 'tr[data-id=\'tenancy-start\']');
+  I.see('01-01-2017', 'tr[data-id=\'tenancy-start\']');
 });
 
 Scenario('When the page loads at /confirm then I should not see their current address', (

--- a/apps/right-to-rent-check/behaviours/customer-email.js
+++ b/apps/right-to-rent-check/behaviours/customer-email.js
@@ -4,6 +4,8 @@ const Emailer = require('hof-behaviour-emailer');
 const path = require('path');
 const moment = require('moment');
 
+const config = require('../../../config');
+
 const obfuscate = str => str.replace(/./g, '*');
 
 const getDataRows = (model, translate) => {
@@ -12,7 +14,7 @@ const getDataRows = (model, translate) => {
   return [
     {
       table: [
-        { label: label('submitted'), value: moment().format('DD-MM-YYYY, hh:mma') },
+        { label: label('submitted'), value: moment().format(config.dateTimeFormat) },
         { label: label('rental-property-address'), value: model['rental-property-address'] },
         { label: label('current-property-address'), value: model['current-property-address'] }
       ]
@@ -22,7 +24,7 @@ const getDataRows = (model, translate) => {
       table: model.tenants.reduce((fields, tenant, i) => fields.concat([
         { linebreak: i > 0 },
         { label: label('tenant-name'), value: tenant['tenant-name'] },
-        { label: label('tenant-dob'), value: moment(tenant['tenant-dob']).format('DD-MM-YYYY') },
+        { label: label('tenant-dob'), value: moment(tenant['tenant-dob']).format(config.dateFormat) },
         { label: label('tenant-country'), value: tenant['tenant-country'] },
         { label: label('tenant-reference-number'), value: obfuscate(tenant['tenant-reference-number']) },
         { label: label('tenant-passport-number'), value: obfuscate(tenant['tenant-passport-number']) },
@@ -53,13 +55,13 @@ const getDataRows = (model, translate) => {
   ].filter(Boolean);
 };
 
-module.exports = config => {
-  if (config.transport !== 'stub' && !config.from && !config.replyTo) {
+module.exports = settings => {
+  if (settings.transport !== 'stub' && !settings.from && !settings.replyTo) {
     // eslint-disable-next-line no-console
     console.warn('WARNING: Email `from` address must be provided. Falling back to stub email transport.');
   }
-  return Emailer(Object.assign({}, config, {
-    transport: config.from ? config.transport : 'stub',
+  return Emailer(Object.assign({}, settings, {
+    transport: settings.from ? settings.transport : 'stub',
     recipient: model => {
       return model.representative === 'agent' ? model['agent-email-address'] : model['landlord-email-address'];
     },

--- a/apps/right-to-rent-check/behaviours/tenants.js
+++ b/apps/right-to-rent-check/behaviours/tenants.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const uuid = require('uuid/v4');
 const moment = require('moment');
 
-const DOB_FORMAT = 'DD-MM-YYYY';
+const config = require('../../../config');
 
 // Find the step that includes the field
 const findStep = (steps, field) =>
@@ -145,11 +145,7 @@ module.exports = fields => {
       const locals = super.locals(req, res);
       locals.tenants = _.cloneDeep(req.sessionModel.get('tenants'));
       locals.tenants.forEach(tenant => {
-        tenant['tenant-dob'] = moment(tenant['tenant-dob'], [
-          'YYYY-MM-DD',
-          'DD-MM-YYYY'
-        ])
-        .format(DOB_FORMAT);
+        tenant['tenant-dob'] = moment(tenant['tenant-dob']).format(config.dateFormat);
       });
       if (locals.tenants.length) {
         locals.hasTenants = true;

--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -237,6 +237,7 @@ module.exports = {
             edit: false
           }, {
             field: 'tenancy-start',
+            parse: d => moment(d).format(config.dateFormat),
             edit: false
           }
         ],
@@ -247,7 +248,7 @@ module.exports = {
               'tenant-name',
               {
                 field: 'tenant-dob',
-                parse: d => moment(d).format('DD-MM-YYYY')
+                parse: d => moment(d).format(config.dateFormat)
               },
               'tenant-country',
               'tenant-reference-number',

--- a/config.js
+++ b/config.js
@@ -5,6 +5,8 @@ const env = process.env.NODE_ENV || 'production';
 const localhost = () => `${process.env.LISTEN_HOST || '0.0.0.0'}:${process.env.PORT || 8080}`;
 
 module.exports = {
+  dateFormat: 'DD-MM-YYYY',
+  dateTimeFormat: 'DD-MM-YYYY, hh:mma',
   postcode: {
     mock: '/api/postcode-test',
     hostname: env !== 'production' ?


### PR DESCRIPTION
The format string was being spread around the codebase. Consolidate by moving it into configuration and ensuring we use a consistent format wherever formatted dates are displayed.

Fixes the formatting of the "move in date" field on the confirm page as a side-effect.