### PR TITLE
[LCS-343] - Send caseworker emails on submission

### DIFF
--- a/apps/right-to-rent-check/behaviours/caseworker-email.js
+++ b/apps/right-to-rent-check/behaviours/caseworker-email.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const Emailer = require('hof-behaviour-emailer');
+const path = require('path');
+
+module.exports = config => {
+  if (config.transport !== 'stub' && !config.from && !config.replyTo) {
+    // eslint-disable-next-line no-console
+    console.warn('WARNING: Email `from` address must be provided. Falling back to stub email transport.');
+  }
+  return Emailer(Object.assign({}, config, {
+    transport: config.from ? config.transport : 'stub',
+    recipient: config.caseworker,
+    subject: (model, translate) => translate('email.caseworker.subject'),
+    template: path.resolve(__dirname, '../emails/caseworker.html')
+  }));
+};

--- a/apps/right-to-rent-check/emails/caseworker.html
+++ b/apps/right-to-rent-check/emails/caseworker.html
@@ -1,0 +1,1 @@
+<p><a href="{{pdf-upload}}">View the request</a></p>

--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -25,6 +25,7 @@ const dynamicTitle = require('./behaviours/dynamic-title');
 const pdfUploader = require('./behaviours/pdf-uploader');
 const config = require('../../config');
 const customerEmailer = require('./behaviours/customer-email')(config.email);
+const caseworkerEmailer = require('./behaviours/caseworker-email')(config.email);
 
 module.exports = {
   name: 'right-to-rent-check',
@@ -298,7 +299,7 @@ module.exports = {
       next: '/declaration'
     },
     '/declaration': {
-      behaviours: [customerEmailer, getDeclarer, pdfUploader, 'complete'],
+      behaviours: [caseworkerEmailer, customerEmailer, getDeclarer, pdfUploader, 'complete'],
       next: '/confirmation'
     },
     '/confirmation': {},

--- a/apps/right-to-rent-check/translations/src/en/email.json
+++ b/apps/right-to-rent-check/translations/src/en/email.json
@@ -1,4 +1,7 @@
 {
+  "caseworker": {
+    "subject": "You have a new request for a Home Office Right to Rent check"
+  },
   "customer": {
     "subject": "Confirmation of your Home Office right to rent check",
     "fields": {

--- a/config.js
+++ b/config.js
@@ -40,6 +40,7 @@ module.exports = {
   email: {
     from: process.env.FROM_ADDRESS || '',
     transport: process.env.EMAIL_TRANSPORT || 'ses',
+    caseworker: process.env.CASEWORKER_EMAIL || '',
     transportOptions: {
       accessKeyId: process.env.HOF_SES_USER || process.env.AWS_USER || '',
       secretAccessKey: process.env.HOF_SES_PASSWORD || process.env.AWS_PASSWORD || ''


### PR DESCRIPTION
Send an email to a configured caseworker email address with a link to the generated PDF document containing application data.

Note: There are still a number of related known bugs around PDF generation and storage, but those aren't related to the email functionality itself.