### PR TITLE
[LCS-371] - Fix: country typeahead with no JS

### DIFF
--- a/apps/right-to-rent-check/fields.js
+++ b/apps/right-to-rent-check/fields.js
@@ -61,8 +61,7 @@ module.exports = {
   'tenant-country': {
     mixin: 'select',
     validate: 'required',
-    className: ['typeahead', 'js-hidden'],
-    options: [''].concat(require('homeoffice-countries').allCountries)
+    options: require('hof-util-countries')()
   },
   'tenant-dob': dateComponent('tenant-dob', {
     validate: ['required', 'date', 'before']

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "hof": "^13.0.0",
-    "hof-behaviour-emailer": "^2.2.0",
     "hof-behaviour-address-lookup": "^2.2.0",
+    "hof-behaviour-emailer": "^2.2.0",
     "hof-behaviour-summary-page": "^3.0.0",
     "hof-build": "^1.5.0",
     "hof-component-date": "^1.4.0",
@@ -25,7 +25,7 @@
     "hof-frontend-toolkit": "^2.1.0",
     "hof-model": "^3.1.2",
     "hof-theme-govuk": "^4.1.0",
-    "homeoffice-countries": "^0.1.0",
+    "hof-util-countries": "^1.0.0",
     "is-pdf": "^1.0.0",
     "jquery": "^3.1.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This is when javascript is turned off the countries where not displaying but just the translations