### PR TITLE
Restore className property that was accidentally removed

### DIFF
--- a/apps/right-to-rent-check/fields.js
+++ b/apps/right-to-rent-check/fields.js
@@ -61,6 +61,7 @@ module.exports = {
   'tenant-country': {
     mixin: 'select',
     validate: 'required',
+    className: ['typeahead', 'js-hidden'],
     options: require('hof-util-countries')()
   },
   'tenant-dob': dateComponent('tenant-dob', {


### PR DESCRIPTION
These classes are required for typeahead functionality.