### PR TITLE
Fix functional test address inputs

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/confirm/agent-in-property.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/agent-in-property.js
@@ -20,7 +20,7 @@ Before((
     'agent-name': 'abc',
     'agent-email-address': 'abc@abc-corp.com',
     'agent-phone-number': '12345',
-    'agent-address': 'CR0 2EU',
+    'agent-address-postcode': 'CR0 2EU',
     'landlord-address-postcode': 'CR0 2EU'
   });
 });

--- a/apps/right-to-rent-check/acceptance/features/confirm/agent.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/agent.js
@@ -20,7 +20,7 @@ Before((
   I.completeToStep('/confirm', {
     'documents-check': 'no',
     'rental-property-location': 'england',
-    'rental-property-address': 'CR0 2EU',
+    'rental-property-address-postcode': 'CR0 2EU',
     'living-status': 'no',
     'tenant-in-uk': 'yes',
     'tenant-current-address-postcode': 'CR0 2EU',
@@ -30,7 +30,7 @@ Before((
     'agent-name': 'abc',
     'agent-email-address': 'abc@abc-corp.com',
     'agent-phone-number': '12345',
-    'agent-address': 'CR0 2EU',
+    'agent-address-postcode': 'CR0 2EU',
     'landlord-name': 'Johnny',
     'landlord-address-postcode': 'CR0 2EU'
   });

--- a/apps/right-to-rent-check/acceptance/features/confirm/edit-a-tenant.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/edit-a-tenant.js
@@ -20,7 +20,7 @@ Before((
   I.completeToStep('/confirm', {
     'documents-check': 'no',
     'rental-property-location': 'england',
-    'rental-property-address': 'CR0 2EU',
+    'rental-property-address-postcode': 'CR0 2EU',
     'living-status': 'no',
     'tenant-in-uk': 'yes',
     'tenant-current-address-postcode': 'CR0 2EU',


### PR DESCRIPTION
The postcodes need to be input in the postcode fields, otherwise a random postcode is used, and so the eventual assertions may not hold.