### PR TITLE
[LCS-380] - Fix date of birth being removed from tenants array

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/confirm/edit-tenant-documents.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/edit-tenant-documents.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const steps = require('../../../');
+
+Feature('Given I have completed to /confirm with one tenant and no documents');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/confirm', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'rental-property-address-postcode': 'CR0 2EU',
+    'living-status': 'no',
+    'tenant-in-uk': 'yes',
+    'tenant-add-another': 'no',
+    'tenant-dob-day': '1',
+    'tenant-dob-month': '1',
+    'tenant-dob-year': '1990',
+    'tenant-additional-details': null
+  });
+});
+
+Scenario('When I edit to add a document then details are preserved', (
+  I
+) => {
+  // data is visible
+  I.see('Not provided', 'tr[data-id=\'tenant-reference-number\']');
+  I.see('Not provided', 'tr[data-id=\'tenant-passport-number\']');
+  I.see('Not provided', 'tr[data-id=\'tenant-brp-number\']');
+  I.see('Not provided', 'tr[data-id=\'tenant-recorded-delivery-number\']');
+  I.see('01-01-1990', 'tr[data-id=\'tenant-dob\']')
+
+  // go back to edit reference number
+  I.click('#tenant-reference-number-change');
+
+  // add a reference number
+  I.click('#tenant-additional-details-reference-number');
+  I.fillField('#tenant-reference-number', '0123456789');
+  // continue
+  I.click('input[type="submit"]');
+
+  // I am returned to confirm page
+  I.seeInCurrentUrl('/confirm');
+  // reference number is updated
+  I.see('0123456789', 'tr[data-id=\'tenant-reference-number\']');
+  // dob is preserved (bugfix)
+  I.see('01-01-1990', 'tr[data-id=\'tenant-dob\']');
+});
+


### PR DESCRIPTION
Code that mapped fields from top level of model to tenants array was expecting fields to always be defined as strings. Because date of birth includes a parse function it was defined as an object so was not picked up.

Add a `map` to normalise field configuration to list of field keys.

Additionally cleans up some of the code and tests around this functionality to make them a little easier to read/follow - in particular swapping `foo`, `baz` for real-life field names.