### PR TITLE
[LCS-347] - Update content on documents check page

### DIFF
--- a/apps/right-to-rent-check/translations/src/en/fields.json
+++ b/apps/right-to-rent-check/translations/src/en/fields.json
@@ -1,6 +1,6 @@
 {
   "documents-check": {
-    "legend": "Does the person have documents?",
+    "legend": "Does the person have documents you can check?",
     "options": {
       "yes": {
         "label": "Yes"

--- a/apps/right-to-rent-check/translations/src/en/pages.json
+++ b/apps/right-to-rent-check/translations/src/en/pages.json
@@ -4,7 +4,8 @@
     "intro": "Answer up to 6 questions to make sure you can use this service."
   },
   "documents-check": {
-    "intro": "If the person has documents showing whether they can live in the UK or not, you need to do the check yourself."
+    "header": "Does the person have documents you can check?",
+    "intro": "If the tenant can show you a document proving they can live in the UK, you need to do the check yourself."
   },
   "documents-check-yourself": {
     "header": "You need to do the right to rent check yourself",


### PR DESCRIPTION
Changes header and intro text.

Explicitly set page header in pages translation as it is more predictable to manage when all the page content is set in the same place, and not split between two different files.