### PR TITLE
[LCS-338] - Reduce width of postcode fields

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -164,3 +164,7 @@ ul {
   margin-top: 0.5em;
   margin-bottom: 2em;
 }
+
+input[name*="postcode"] {
+  @extend .form-control-1-4;
+}


### PR DESCRIPTION
Reduces the width of any postcode field using the govuk elements form styles defined here: https://govuk-elements.herokuapp.com/form-elements/example-form-elements/

The selector will be reliable because postcode field configuration is driven from the address lookup behaviour, and so the name of the fields will always contain `postcode`. There are some old browsers that won't support the selector, but they will revert to a standard width field.