### PR TITLE
[LCS-341] - Fix preselected tenant details checkboxes

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/tenant-additional-details.js
+++ b/apps/right-to-rent-check/acceptance/features/tenant-additional-details.js
@@ -1,22 +1,27 @@
 'use strict';
 
-const _ = require('lodash');
-const steps = require('../../');
-
 Feature('Given I am at /tenant-additional-details');
 
 Before((
   I,
   tenantAdditionalDetailsPage
 ) => {
-  I.visitPage(tenantAdditionalDetailsPage, steps);
+  I.amOnPage('/');
+  I.completeToStep(tenantAdditionalDetailsPage.url, {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'living-status': 'yes',
+    'tenancy-start-day': '1',
+    'tenancy-start-month': '1',
+    'tenancy-start-year': '2017'
+  });
 });
 
 Scenario('When the page loads Then the correct fields are visible', (
   I,
   tenantAdditionalDetailsPage
 ) => {
-  I.seeElements(_.values(tenantAdditionalDetailsPage.fields));
+  I.seeElements(Object.values(tenantAdditionalDetailsPage.fields));
 });
 
 Scenario('When a visible field is checked Then its hidden field becomes visible', (
@@ -24,7 +29,7 @@ Scenario('When a visible field is checked Then its hidden field becomes visible'
   tenantAdditionalDetailsPage
 ) => {
   tenantAdditionalDetailsPage.checkFields();
-  I.seeElements(_.values(tenantAdditionalDetailsPage.hidden));
+  I.seeElements(Object.values(tenantAdditionalDetailsPage.hidden));
 });
 
 Scenario('When a field is visible and empty And I submit the form Then I see errors', (
@@ -33,7 +38,7 @@ Scenario('When a field is visible and empty And I submit the form Then I see err
 ) => {
   tenantAdditionalDetailsPage.checkFields();
   I.submitForm();
-  I.seeErrors(_.values(tenantAdditionalDetailsPage.hidden));
+  I.seeErrors(Object.values(tenantAdditionalDetailsPage.hidden));
 });
 
 Scenario('When all fields are empty And I submit the form Then I am redirected to /request-another-tenant', (
@@ -65,3 +70,27 @@ Scenario('When I check all fields and complete their hidden fields Then I am red
   I.submitForm();
   I.seeInCurrentUrl(requestAnotherTenantPage.url);
 });
+
+Scenario('Deleting a tenant, and then adding another will have checkboxes unchecked (Bugfix)', (
+  I,
+  tenantAdditionalDetailsPage
+) => {
+  // GIVEN I have added two tenants with all checkboxes selected
+  tenantAdditionalDetailsPage.completeAllFields();
+  I.submitForm();
+  I.completeToStep(tenantAdditionalDetailsPage.url, { 'tenant-add-another': 'yes' });
+  tenantAdditionalDetailsPage.completeAllFields();
+  I.submitForm();
+
+  // AND I delete a tenant
+  I.click('.tenant-details a.button-delete');
+
+  // WHEN I add another tenant
+  I.completeToStep(tenantAdditionalDetailsPage.url, { 'tenant-add-another': 'yes' });
+
+  // THEN no additional details checkboxes are selected
+  Object.values(tenantAdditionalDetailsPage.fields).forEach(field => {
+    I.dontSeeCheckboxIsChecked(field);
+  });
+});
+

--- a/apps/right-to-rent-check/acceptance/pages/tenant-additional-details.js
+++ b/apps/right-to-rent-check/acceptance/pages/tenant-additional-details.js
@@ -12,7 +12,7 @@ module.exports = {
     I = require('so-acceptance/steps')();
   },
 
-  url: 'tenant-additional-details',
+  url: '/tenant-additional-details',
 
   fields: {
     'reference-number': '#tenant-additional-details-reference-number',

--- a/apps/right-to-rent-check/behaviours/tenants.js
+++ b/apps/right-to-rent-check/behaviours/tenants.js
@@ -125,7 +125,7 @@ module.exports = fields => {
 
     saveValues(req, res, callback) {
       super.saveValues(req, res, (err) => {
-        req.sessionModel.unset(fields.concat('tenant-uuid', 'redirectTo'));
+        req.sessionModel.unset(fields.concat('tenant-uuid', 'tenant-additional-details', 'redirectTo'));
         callback(err);
       });
     }

--- a/test/unit/behaviours/tenants.js
+++ b/test/unit/behaviours/tenants.js
@@ -170,8 +170,9 @@ describe('behaviours/tenants', () => {
     it('unsets all fields and the tenant-uuid from the session', (done) => {
       controller.saveValues(req, res, (err) => {
         expect(err).to.not.exist;
+        const expectedUnset = fields.concat('tenant-uuid', 'tenant-additional-details', 'redirectTo');
         expect(sessionModel.unset)
-          .to.have.been.calledWithExactly(fields.concat('tenant-uuid', 'redirectTo'));
+          .to.have.been.calledWith(sinon.match.array.contains(expectedUnset));
         done();
       });
     });


### PR DESCRIPTION
Correctly unsets the checkboxes on the tenant-additional-details page so that they are not left pre-populated in certain circumstances.