### PR TITLE
[LCS-385] - Ensure confirm page links to correct step on edit

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/landlord-agent.js
+++ b/apps/right-to-rent-check/acceptance/features/landlord-agent.js
@@ -1,14 +1,20 @@
 'use strict';
 
-const steps = require('../../');
-
 Feature('landlord agent step');
 
 Before((
   I,
   landlordAgentPage
 ) => {
-  I.visitPage(landlordAgentPage, steps);
+  I.amOnPage('/');
+  I.completeToStep(landlordAgentPage.url, {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'rental-property-address-postcode': 'CR0 2EU',
+    'living-status': 'no',
+    'tenant-in-uk': 'yes',
+    'tenant-add-another': 'no'
+  });
 });
 
 Scenario('I select Landlord, click ‘Continue’ & go to /landlord-details step', (
@@ -40,3 +46,21 @@ Scenario('I see errors when I submit form after leaving both buttons unselected'
     landlordAgentPage.representativeGroup
   ]);
 });
+
+Scenario('When editing the landlord name from the /confirm page I am returned to the correct step (bugfix)', (
+  I
+) => {
+  // continue to confirm page
+  I.completeToStep('/confirm', {
+    representative: 'agent'
+  });
+  // edit landlord name
+  I.click('#landlord-name-change');
+
+  I.seeInCurrentUrl('/landlord-name');
+  I.dontSeeElement('#landlord-company');
+  I.dontSeeElement('#landlord-email-address');
+  I.dontSeeElement('#landlord-phone-number');
+});
+
+

--- a/apps/right-to-rent-check/acceptance/pages/landlord-or-agent.js
+++ b/apps/right-to-rent-check/acceptance/pages/landlord-or-agent.js
@@ -3,7 +3,7 @@
 module.exports = {
   _init() {},
 
-  url: 'landlord-or-agent',
+  url: '/landlord-or-agent',
   fields: {
     landlord: '#representative-landlord',
     agent: '#representative-agent'

--- a/apps/right-to-rent-check/behaviours/confirm-tenants.js
+++ b/apps/right-to-rent-check/behaviours/confirm-tenants.js
@@ -2,9 +2,9 @@
 
 const _ = require('lodash');
 
-const findStep = (steps, field) => {
-  return _.findKey(steps, step => {
-    return step.fields && step.fields.indexOf(field) !== -1;
+const findStep = (steps, completed, field) => {
+  return _.findKey(steps, (step, route) => {
+    return step.fields && step.fields.indexOf(field) !== -1 && completed.indexOf(route) !== -1;
   });
 };
 
@@ -31,7 +31,7 @@ module.exports = superclass => class extends superclass {
       // an edit button has been clicked
       if (req.params.action === 'edit') {
         // redirect to the page the query field is on
-        const step = findStep(req.form.options.steps, req.query.field);
+        const step = findStep(req.form.options.steps, req.sessionModel.get('steps'), req.query.field);
         values.redirectTo = `${step}/edit#${req.query.field}`;
 
         // if an id is set, this is a collection

--- a/test/unit/behaviours/confirm-tenants.js
+++ b/test/unit/behaviours/confirm-tenants.js
@@ -80,6 +80,11 @@ describe('behaviours/confirm-tenants', () => {
           'other-dob'
         ]
       },
+      '/step-d': {
+        fields: [
+          'other-name'
+        ]
+      },
       '/confirm': {
         sections: sections
       }
@@ -98,6 +103,7 @@ describe('behaviours/confirm-tenants', () => {
     get.withArgs('landlord-email').returns('linda@test.com');
     get.withArgs('other-name').returns('denis');
     get.withArgs('other-dob').returns('1980-01-01');
+    get.withArgs('steps').returns(['/step-a', '/step-b', '/step-c']);
   });
 
   it('exports a function', () => {
@@ -221,6 +227,19 @@ describe('behaviours/confirm-tenants', () => {
           expect(err).to.not.exist;
           expect(req.sessionModel.set.args[0][0]).to.include({
             redirectTo: '/step-c/edit#other-name'
+          });
+          done();
+        });
+      });
+
+      it('redirectTo is set to step the user has visited if it appears on more than one step', (done) => {
+        get.withArgs('steps').returns(['/step-a', '/step-b', '/step-d']);
+        req.params.action = 'edit';
+        req.query.field = 'other-name';
+        controller.getValues(req, res, (err) => {
+          expect(err).to.not.exist;
+          expect(req.sessionModel.set.args[0][0]).to.include({
+            redirectTo: '/step-d/edit#other-name'
           });
           done();
         });


### PR DESCRIPTION
When a field appears in more than one step then the logic to find the url to redirect to when editing the field can point to the wrong place. When checking which steps contain a field, add an additional check that the user has previously visited that step.
