### PR TITLE
Fix manual address being cleared on edit

### DIFF
--- a/apps/right-to-rent-check/acceptance/features/confirm/edit-landlord-address.js
+++ b/apps/right-to-rent-check/acceptance/features/confirm/edit-landlord-address.js
@@ -1,0 +1,27 @@
+'use strict';
+
+Feature('Given I have completed to /confirm as a landlord');
+
+Before((
+  I
+) => {
+  I.amOnPage('/');
+  I.completeToStep('/confirm', {
+    'documents-check': 'no',
+    'rental-property-location': 'england',
+    'living-status': 'no',
+    'tenant-in-uk': 'yes',
+    'tenant-add-another': 'no',
+    'representative': 'landlord',
+    'landlord-address-postcode': 'A1 1AA', // a postcode that will trigger manual entry
+    'landlord-address': '1 High Street'
+  });
+});
+
+Scenario('When I edit my address manually the data is preserved (bugfix)', (
+  I
+) => {
+  I.click('#landlord-address-change');
+  I.click('a[href*="step=manual"]');
+  I.see('1 High Street');
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "hof": "^13.0.1",
-    "hof-behaviour-address-lookup": "^2.2.0",
+    "hof-behaviour-address-lookup": "^2.2.1",
     "hof-behaviour-emailer": "^2.2.0",
     "hof-behaviour-summary-page": "^3.0.0",
     "hof-build": "^1.5.0",


### PR DESCRIPTION
Fix was in hof-behaviour-address-lookup but bump the version to the fix, and include a regression test.