### PR TITLE
Add pages for privacy-policy and cookies

### DIFF
--- a/apps/right-to-rent-check/index.js
+++ b/apps/right-to-rent-check/index.js
@@ -31,6 +31,10 @@ module.exports = {
   name: 'right-to-rent-check',
   params: '/:action?/:id?',
   behaviours: [require('./behaviours/filter-fields')],
+  pages: {
+    '/privacy-policy': 'privacy-policy',
+    '/cookies': 'cookies'
+  },
   steps: {
     '/eligibility-check': {
       next: '/documents-check'

--- a/apps/right-to-rent-check/views/content/cookies.md
+++ b/apps/right-to-rent-check/views/content/cookies.md
@@ -1,0 +1,56 @@
+## Cookies
+
+This service puts small files (known as ‘cookies’) onto your computer in order to:
+
+* remember what messages you’ve seen so you’re not shown them again
+* understand how you use the service so we can update and improve it
+* temporarily store information you enter to support your application
+
+<div class="panel-indent">
+  <p>The cookies we use don’t identify you personally.</p>
+</div>
+
+Find out <a href="http://www.aboutcookies.org/Default.aspx?page=1" rel="external">how to manage cookies</a>
+
+## Introductory cookie message
+
+When you first use the service we show a ‘cookie message’. We then store a cookie on your computer so it knows not to show this message again.
+
+| Name                  |    Purpose                  |  Expires |
+|:----------------------|:----------------------------|:---------|
+| seen\_cookie\_message | Lets us know you’ve already seen our cookie message | 1 Month
+
+
+## Measuring site use
+
+We use Google Analytics to collect information about how you use this service. This helps us check it’s meeting your needs and make improvements.
+
+Google Analytics stores information about:
+
+* how you got to the site
+* pages you visit and how long you spend on them
+* what you click on
+
+No personal details are stored with this information, so you can’t be identified.
+
+| Name |    Purpose                    |  Expires   |
+|:-----|:--------------------------    |:---------  |
+| _ga  | Used to distinguish users     | 2 years    |
+| _gat | Used to throttle request rate | 10 minutes |
+
+<div class="panel-indent">
+  <p>Google isn’t allowed to use or share our analytics data.</p>
+</div>
+
+You can <a href="https://tools.google.com/dlpage/gaoptout" rel="external">opt out of Google Analytics cookies</a>
+
+## Session cookies
+
+Session cookies are downloaded each time you visit the service and deleted when you close your browser. They help the service to work properly.
+
+| Name             |    Purpose                    |  Expires   |
+|:-----            |:--------------------------    |:---------  |
+| hmbrp.sid        | Stores a session ID and temporarily stores data you enter to enable you to make an application | When you close your browser |
+| hof-wizard-sc    | Tells us when your session starts so we can tell you if it expires | When you close your browser |
+| hof-cookie-check | Tells us you have already allowed cookies so we don’t need to ask you again | When you close your browser |
+

--- a/apps/right-to-rent-check/views/content/privacy-policy.md
+++ b/apps/right-to-rent-check/views/content/privacy-policy.md
@@ -1,19 +1,21 @@
+# Privacy Policy
+
 This privacy policy relates to the Home Office right to rent service for landlords and agents.
 
 ## Information we ask for
 
-When you use this service we'll ask you for your: 
+When you use this service we'll ask you for your:
 
-* full name 
-* contact details, including phone number, postal address and email address 
+* full name
+* contact details, including phone number, postal address and email address
 * rental property address
 * rental company name (if applicable)
 
-We will also ask for information about your tenant including: 
+We will also ask for information about your tenant including:
 
-* name 
-* date of birth 
-* country of nationality 
+* name
+* date of birth
+* country of nationality
 * details of documents relating to immigration status, such as passport or biometric residence permit (optional)
 
 This information will be securely held in line with our [cookie policy](./cookies) so that you can progress through and complete your application. Your information will be stored by the government for future reference.

--- a/apps/right-to-rent-check/views/cookies.html
+++ b/apps/right-to-rent-check/views/cookies.html
@@ -1,0 +1,5 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#markdown}}cookies{{/markdown}}
+  {{/page-content}}
+{{/partials-page}}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ settings.routes = settings.routes.map(route => require(route));
 settings.root = __dirname;
 settings.start = false;
 settings.redis = config.redis;
+settings.getCookies = settings.getTerms = false;
 
 if (process.env.NODE_ENV !== 'production') {
   settings.middleware = [require('./mock-apis')];

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "npm run build"
   },
   "dependencies": {
-    "hof": "^13.0.1",
+    "hof": "^13.1.1",
     "hof-behaviour-address-lookup": "^2.2.1",
     "hof-behaviour-emailer": "^2.2.0",
     "hof-behaviour-summary-page": "^3.0.0",


### PR DESCRIPTION
- Add pages for privacy-policy and cookies to override
inherited cooies resource and amend links in the footer.
- footer links include /cookies and /privacy-policy,
and not /terms-and-conditions
- Swtich off cookies and terms hof middleware