### PR TITLE
Remove pre-authed bearer token from upload urls

### DIFF
--- a/apps/right-to-rent-check/models/upload.js
+++ b/apps/right-to-rent-check/models/upload.js
@@ -28,11 +28,6 @@ module.exports = class UploadModel extends Model {
         }
         resolve(data);
       });
-    }).then(data => {
-      return this.auth().then(bearer => {
-        data.url = (data.url.replace('/file', '/vault')) + '&token=' + bearer.bearer;
-        return data;
-      });
     });
   }
 

--- a/test/unit/models/upload.js
+++ b/test/unit/models/upload.js
@@ -48,7 +48,7 @@ describe('Upload Model', () => {
       const response = model.save();
       return expect(response).to.eventually.deep.equal({
         api: 'response',
-        url: '/vault/12341212132123?foo=bar&token=myaccesstoken'
+        url: '/file/12341212132123?foo=bar'
       });
     });
 


### PR DESCRIPTION
When we send links to uploaded files to caseworkers we need them to have to login themselves to access the files (otherwise they would be insecure in email transit). Remove the pre-authed bearer token from the created url as this was originally used for firearms where files would be accessed by API.