### PR TITLE
Use default govuk h1 styling

### DIFF
--- a/apps/right-to-rent-check/views/content/cookies.md
+++ b/apps/right-to-rent-check/views/content/cookies.md
@@ -1,4 +1,4 @@
-# <div class='heading-large'> Cookies </div>
+# Cookies
 
 This service puts small files (known as ‘cookies’) onto your computer in order to:
 

--- a/apps/right-to-rent-check/views/content/privacy-policy.md
+++ b/apps/right-to-rent-check/views/content/privacy-policy.md
@@ -1,4 +1,4 @@
-# <div class='heading-large'> Privacy Policy </div>
+# Privacy Policy
 
 This privacy policy relates to the Home Office right to rent service for landlords and agents.
 

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -1,9 +1,5 @@
 @import "hof-theme-govuk";
 
-h1 {
-  @include bold-24;
-}
-
 .page-header {
   h1 {
     font-size: 1.75em;


### PR DESCRIPTION

Previously, we were overriding the govuk h1 styling by making it smaller.  This was against the standards and not as accessible

**Standard h1 styling**
![screen shot 2018-01-04 at 11 08 51](https://user-images.githubusercontent.com/12494656/34561444-f2157e3a-f141-11e7-80ef-9dabb690cf7d.png)