### PR TITLE
fix param values in deploy triggers

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -103,7 +103,7 @@ pipeline:
     repo: UKHomeOffice/kube-right-to-rent
     branch: master
     deploy_to: rent-check-preprod
-    params: APP_IMAGE_TAG=$${DRONE_COMMIT_SHA},KUBE_NAMESPACE=rent-check-preprod
+    params: APP_IMAGE_TAG=${DRONE_COMMIT_SHA},KUBE_NAMESPACE=rent-check-preprod
     when:
       event: tag
 
@@ -115,7 +115,7 @@ pipeline:
     repo: UKHomeOffice/kube-rent-check
     branch: master
     deploy_to: rent-check
-    params: APP_IMAGE_TAG=$${DRONE_COMMIT_SHA},KUBE_NAMESPACE=rent-check
+    params: APP_IMAGE_TAG=${DRONE_COMMIT_SHA},KUBE_NAMESPACE=rent-check
     when:
       event: deployment
       environment: production


### PR DESCRIPTION
drone-trigger params must only have a single `$` opposed to docker where they need `$$`